### PR TITLE
Feature/insurance/fund

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "margined_insurance_fund"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-bignumber",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.8.1",
+ "margined_perp",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "margined_perp"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "packages/*",
     "contracts/margined_engine",
+    "contracts/margined_insurance_fund",
     "contracts/margined_pricefeed",
     "contracts/margined_vamm",
     "contracts/mocks/*",

--- a/contracts/margined_insurance_fund/Cargo.toml
+++ b/contracts/margined_insurance_fund/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "margined_insurance_fund"
+version = "0.1.0"
+authors = ["Margined Protocol"]
+edition = "2018"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.4
+"""
+
+[dependencies]
+cosmwasm-std = { version = "0.16.3" }
+cosmwasm-storage = { version = "0.16.3" }
+cosmwasm-bignumber = "2.2.0"
+cw-storage-plus = "0.8.0"
+margined_perp = { version = "0.1.0", path = "../../packages/margined_perp" }
+schemars = "0.8"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0" }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "1.0.0-beta" }

--- a/contracts/margined_insurance_fund/README.md
+++ b/contracts/margined_insurance_fund/README.md
@@ -1,5 +1,3 @@
-# Margined Protocol Price Feed
+# Margined Protocol Insurance Fund
 
-**NOTE:** In the current state the price feed is entirely centralised around the contract deployer just while the other logic is developed.
-
-Price feed integrates against the [TeFi oracle hub](https://github.com/terra-money/tefi-oracle-contracts). Additionally, the price feed performs other logic, e.g. TWAP, of data retrieved from the data oracles for use throughout the protocol.
+**NOTE:** 

--- a/contracts/margined_insurance_fund/README.md
+++ b/contracts/margined_insurance_fund/README.md
@@ -1,0 +1,5 @@
+# Margined Protocol Price Feed
+
+**NOTE:** In the current state the price feed is entirely centralised around the contract deployer just while the other logic is developed.
+
+Price feed integrates against the [TeFi oracle hub](https://github.com/terra-money/tefi-oracle-contracts). Additionally, the price feed performs other logic, e.g. TWAP, of data retrieved from the data oracles for use throughout the protocol.

--- a/contracts/margined_insurance_fund/rustfmt.toml
+++ b/contracts/margined_insurance_fund/rustfmt.toml
@@ -1,0 +1,15 @@
+# stable
+newline_style = "unix"
+hard_tabs = false
+tab_spaces = 4
+
+# unstable... should we require `rustup run nightly cargo fmt` ?
+# or just update the style guide when they are stable?
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#overflow_delimited_expr = true
+#reorder_impl_items = true
+#struct_field_align_threshold = 20
+#struct_lit_single_line = true
+#report_todo = "Always"
+

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -1,0 +1,50 @@
+use crate::error::ContractError;
+use crate::{
+    handle::{update_config, add_amm, remove_amm},
+    query::{query_config, query_amm},
+    state::{store_config, Config},
+};
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+};
+use margined_perp::margined_insurance_fund::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let config = Config {
+        owner: info.sender,
+    };
+
+    store_config(deps.storage, &config)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::UpdateConfig { owner } => update_config(deps, info, owner),
+        ExecuteMsg::AddAMM { amm } => add_amm(deps, info, amm),
+        ExecuteMsg::RemoveAMM { amm } => remove_amm(deps, info, amm),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::GetAMM {amm} => to_binary(&query_amm(deps, amm)?),
+    }
+}

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -32,8 +32,8 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::UpdateConfig { owner } => update_config(deps, info, owner),
-        ExecuteMsg::AddAMM { amm } => add_amm(deps, info, amm),
-        ExecuteMsg::RemoveAMM { amm } => remove_amm(deps, info, amm),
+        ExecuteMsg::AddAmm { amm } => add_amm(deps, info, amm),
+        ExecuteMsg::RemoveAmm { amm } => remove_amm(deps, info, amm),
     }
 }
 
@@ -41,6 +41,6 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::GetAMM { amm } => to_binary(&query_amm(deps, amm)?),
+        QueryMsg::GetAmm { amm } => to_binary(&query_amm(deps, amm)?),
     }
 }

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::{
-    handle::{add_amm, remove_amm, update_config},
-    query::{query_amm, query_config},
+    handle::{add_vamm, remove_vamm, update_config},
+    query::{query_config, query_is_vamm},
     state::{store_config, Config},
 };
 #[cfg(not(feature = "library"))]
@@ -32,8 +32,8 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::UpdateConfig { owner } => update_config(deps, info, owner),
-        ExecuteMsg::AddAmm { amm } => add_amm(deps, info, amm),
-        ExecuteMsg::RemoveAmm { amm } => remove_amm(deps, info, amm),
+        ExecuteMsg::AddVamm { vamm } => add_vamm(deps, info, vamm),
+        ExecuteMsg::RemoveVamm { vamm } => remove_vamm(deps, info, vamm),
     }
 }
 
@@ -41,6 +41,6 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::GetAmm { amm } => to_binary(&query_amm(deps, amm)?),
+        QueryMsg::IsVamm { vamm } => to_binary(&query_is_vamm(deps, vamm)?),
     }
 }

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -1,14 +1,12 @@
 use crate::error::ContractError;
 use crate::{
-    handle::{update_config, add_amm, remove_amm},
-    query::{query_config, query_amm},
+    handle::{add_amm, remove_amm, update_config},
+    query::{query_amm, query_config},
     state::{store_config, Config},
 };
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
-};
+use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use margined_perp::margined_insurance_fund::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -16,11 +14,9 @@ pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    msg: InstantiateMsg,
+    _msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    let config = Config {
-        owner: info.sender,
-    };
+    let config = Config { owner: info.sender };
 
     store_config(deps.storage, &config)?;
 
@@ -42,9 +38,9 @@ pub fn execute(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::GetAMM {amm} => to_binary(&query_amm(deps, amm)?),
+        QueryMsg::GetAMM { amm } => to_binary(&query_amm(deps, amm)?),
     }
 }

--- a/contracts/margined_insurance_fund/src/error.rs
+++ b/contracts/margined_insurance_fund/src/error.rs
@@ -1,0 +1,11 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+}

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, DepsMut, MessageInfo, Response};
+use cosmwasm_std::{DepsMut, MessageInfo, Response};
 
 use crate::{
     error::ContractError,
@@ -17,7 +17,7 @@ pub fn update_config(
         return Err(ContractError::Unauthorized {});
     }
 
-    // change owner of amm
+    // change owner of insurance fund contract
     if let Some(owner) = owner {
         config.owner = deps.api.addr_validate(owner.as_str())?;
     }
@@ -27,7 +27,7 @@ pub fn update_config(
     Ok(Response::default())
 }
 
-pub fn add_amm(deps: DepsMut, info: MessageInfo, amm: Addr) -> Result<Response, ContractError> {
+pub fn add_amm(deps: DepsMut, info: MessageInfo, amm: String) -> Result<Response, ContractError> {
     let config: Config = read_config(deps.storage)?;
 
     // check permission
@@ -35,16 +35,20 @@ pub fn add_amm(deps: DepsMut, info: MessageInfo, amm: Addr) -> Result<Response, 
         return Err(ContractError::Unauthorized {});
     }
 
-    // check if the address is actually an amm
-    // TODO
+    // validate address
+    let amm_valid = deps.api.addr_validate(&amm)?;
 
     // add the amm
-    save_vamm(deps, amm)?;
+    save_vamm(deps, amm_valid)?;
 
     Ok(Response::default())
 }
 
-pub fn remove_amm(deps: DepsMut, info: MessageInfo, amm: Addr) -> Result<Response, ContractError> {
+pub fn remove_amm(
+    deps: DepsMut,
+    info: MessageInfo,
+    amm: String,
+) -> Result<Response, ContractError> {
     let config: Config = read_config(deps.storage)?;
 
     // check permission
@@ -52,8 +56,11 @@ pub fn remove_amm(deps: DepsMut, info: MessageInfo, amm: Addr) -> Result<Respons
         return Err(ContractError::Unauthorized {});
     }
 
+    // validate address
+    let amm_valid = deps.api.addr_validate(&amm)?;
+
     // remove vamm here
-    remove_vamm(deps, amm)?;
+    remove_vamm(deps, amm_valid)?;
 
     Ok(Response::default())
 }

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -1,0 +1,71 @@
+use cosmwasm_std::{DepsMut, MessageInfo, Response, Addr};
+
+use crate::{
+    error::ContractError,
+    state::{read_config, store_config, Config, read_vamm, save_vamm},
+};
+
+pub fn update_config(
+    deps: DepsMut,
+    info: MessageInfo,
+    owner: Option<String>,
+) -> Result<Response, ContractError> {
+    let mut config: Config = read_config(deps.storage)?;
+
+    // check permission
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // change owner of amm
+    if let Some(owner) = owner {
+        config.owner = deps.api.addr_validate(owner.as_str())?;
+    }
+
+    store_config(deps.storage, &config)?;
+
+    Ok(Response::default())
+}
+
+pub fn add_amm(
+    deps: DepsMut,
+    info: MessageInfo,
+    amm: Addr,
+) -> Result<Response, ContractError> {
+    let mut config: Config = read_config(deps.storage)?;
+
+    // check permission
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized {});
+    } 
+
+    // check if the address is actually an amm
+    // TODO
+
+    // add the amm
+    save_vamm(deps, amm);
+
+    Ok(Response::default())
+}
+
+pub fn remove_amm(
+    deps: DepsMut,
+    info: MessageInfo,
+    amm: Addr,
+) -> Result<Response, ContractError> {
+    let mut config: Config = read_config(deps.storage)?;
+
+    // check permission
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // pop the vamm off here
+    let mut vamms = read_vamm(deps.storage)?.vamms;
+
+
+    // check if the amm is there
+    
+
+    Ok(Response::default())
+}

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{DepsMut, MessageInfo, Response};
 
 use crate::{
     error::ContractError,
-    state::{read_config, remove_vamm, save_vamm, store_config, Config},
+    state::{delist_vamm, read_config, save_vamm, store_config, Config},
 };
 
 pub fn update_config(
@@ -27,7 +27,7 @@ pub fn update_config(
     Ok(Response::default())
 }
 
-pub fn add_amm(deps: DepsMut, info: MessageInfo, amm: String) -> Result<Response, ContractError> {
+pub fn add_vamm(deps: DepsMut, info: MessageInfo, vamm: String) -> Result<Response, ContractError> {
     let config: Config = read_config(deps.storage)?;
 
     // check permission
@@ -36,18 +36,18 @@ pub fn add_amm(deps: DepsMut, info: MessageInfo, amm: String) -> Result<Response
     }
 
     // validate address
-    let amm_valid = deps.api.addr_validate(&amm)?;
+    let vamm_valid = deps.api.addr_validate(&vamm)?;
 
     // add the amm
-    save_vamm(deps, amm_valid)?;
+    save_vamm(deps, vamm_valid)?;
 
     Ok(Response::default())
 }
 
-pub fn remove_amm(
+pub fn remove_vamm(
     deps: DepsMut,
     info: MessageInfo,
-    amm: String,
+    vamm: String,
 ) -> Result<Response, ContractError> {
     let config: Config = read_config(deps.storage)?;
 
@@ -57,10 +57,10 @@ pub fn remove_amm(
     }
 
     // validate address
-    let amm_valid = deps.api.addr_validate(&amm)?;
+    let vamm_valid = deps.api.addr_validate(&vamm)?;
 
     // remove vamm here
-    remove_vamm(deps, amm_valid)?;
+    delist_vamm(deps, vamm_valid)?;
 
     Ok(Response::default())
 }

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -1,8 +1,8 @@
-use cosmwasm_std::{DepsMut, MessageInfo, Response, Addr};
+use cosmwasm_std::{Addr, DepsMut, MessageInfo, Response};
 
 use crate::{
     error::ContractError,
-    state::{read_config, store_config, Config, read_vamm, save_vamm},
+    state::{read_config, remove_vamm, save_vamm, store_config, Config},
 };
 
 pub fn update_config(
@@ -27,45 +27,33 @@ pub fn update_config(
     Ok(Response::default())
 }
 
-pub fn add_amm(
-    deps: DepsMut,
-    info: MessageInfo,
-    amm: Addr,
-) -> Result<Response, ContractError> {
-    let mut config: Config = read_config(deps.storage)?;
-
-    // check permission
-    if info.sender != config.owner {
-        return Err(ContractError::Unauthorized {});
-    } 
-
-    // check if the address is actually an amm
-    // TODO
-
-    // add the amm
-    save_vamm(deps, amm);
-
-    Ok(Response::default())
-}
-
-pub fn remove_amm(
-    deps: DepsMut,
-    info: MessageInfo,
-    amm: Addr,
-) -> Result<Response, ContractError> {
-    let mut config: Config = read_config(deps.storage)?;
+pub fn add_amm(deps: DepsMut, info: MessageInfo, amm: Addr) -> Result<Response, ContractError> {
+    let config: Config = read_config(deps.storage)?;
 
     // check permission
     if info.sender != config.owner {
         return Err(ContractError::Unauthorized {});
     }
 
-    // pop the vamm off here
-    let mut vamms = read_vamm(deps.storage)?.vamms;
+    // check if the address is actually an amm
+    // TODO
 
+    // add the amm
+    save_vamm(deps, amm)?;
 
-    // check if the amm is there
-    
+    Ok(Response::default())
+}
+
+pub fn remove_amm(deps: DepsMut, info: MessageInfo, amm: Addr) -> Result<Response, ContractError> {
+    let config: Config = read_config(deps.storage)?;
+
+    // check permission
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // remove vamm here
+    remove_vamm(deps, amm)?;
 
     Ok(Response::default())
 }

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{DepsMut, MessageInfo, Response};
 
 use crate::{
     error::ContractError,
-    state::{delist_vamm, read_config, save_vamm, store_config, Config},
+    state::{read_config, remove_amm, save_vamm, store_config, Config},
 };
 
 pub fn update_config(

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -60,7 +60,7 @@ pub fn remove_vamm(
     let vamm_valid = deps.api.addr_validate(&vamm)?;
 
     // remove vamm here
-    delist_vamm(deps, vamm_valid)?;
+    remove_amm(deps, vamm_valid)?;
 
     Ok(Response::default())
 }

--- a/contracts/margined_insurance_fund/src/lib.rs
+++ b/contracts/margined_insurance_fund/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod contract;
+mod error;
+mod handle;
+mod query;
+mod state;
+
+#[cfg(test)]
+mod testing;

--- a/contracts/margined_insurance_fund/src/query.rs
+++ b/contracts/margined_insurance_fund/src/query.rs
@@ -1,7 +1,7 @@
-use cosmwasm_std::{Addr, Deps, StdError, StdResult};
-use margined_perp::margined_insurance_fund::{AmmResponse, ConfigResponse};
+use cosmwasm_std::{Deps, StdResult};
+use margined_perp::margined_insurance_fund::{ConfigResponse, VammResponse};
 
-use crate::state::{read_config, read_vamm, Config};
+use crate::state::{is_vamm, read_config, Config};
 
 /// Queries contract config
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
@@ -12,21 +12,15 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     })
 }
 
-/// Queries the AMM with given address
-pub fn query_amm(deps: Deps, amm: String) -> StdResult<AmmResponse> {
-    let amm_valid = deps.api.addr_validate(&amm)?;
+/// Queries if the vAMM with given address is already stored
+pub fn query_is_vamm(deps: Deps, vamm: String) -> StdResult<VammResponse> {
+    // validate address
+    let vamm_valid = deps.api.addr_validate(&vamm)?;
 
-    let amm_list = read_vamm(deps.storage)?.vamms;
+    // read the current storage and pull the vamm list
+    let vamm_bool = is_vamm(deps.storage, vamm_valid);
 
-    let amm_new: Addr = if amm_list.contains(&amm_valid) {
-        amm_valid
-    } else {
-        return Err(StdError::NotFound {
-            kind: "AMM".to_string(),
-        });
-    };
-
-    Ok(AmmResponse { amm: amm_new })
+    Ok(VammResponse { is_vamm: vamm_bool })
 }
 
-//Queries all of the current AMMs
+//Queries all of the current vAMMs

--- a/contracts/margined_insurance_fund/src/query.rs
+++ b/contracts/margined_insurance_fund/src/query.rs
@@ -12,12 +12,14 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     })
 }
 
-///Queries the AMM with given address
-pub fn query_amm(deps: Deps, amm: Addr) -> StdResult<AmmResponse> {
+/// Queries the AMM with given address
+pub fn query_amm(deps: Deps, amm: String) -> StdResult<AmmResponse> {
+    let amm_valid = deps.api.addr_validate(&amm)?;
+
     let amm_list = read_vamm(deps.storage)?.vamms;
 
-    let amm_new: Addr = if amm_list.contains(&amm) {
-        amm
+    let amm_new: Addr = if amm_list.contains(&amm_valid) {
+        amm_valid
     } else {
         return Err(StdError::NotFound {
             kind: "AMM".to_string(),

--- a/contracts/margined_insurance_fund/src/query.rs
+++ b/contracts/margined_insurance_fund/src/query.rs
@@ -3,7 +3,7 @@ use margined_perp::margined_insurance_fund::{AmmResponse, ConfigResponse};
 
 use crate::state::{read_config, read_vamm, Config};
 
-/// Queries contract Config
+/// Queries contract config
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let config: Config = read_config(deps.storage)?;
 

--- a/contracts/margined_insurance_fund/src/query.rs
+++ b/contracts/margined_insurance_fund/src/query.rs
@@ -1,7 +1,7 @@
-use cosmwasm_std::{Deps, StdResult, Addr, StdError};
-use margined_perp::margined_insurance_fund::{ConfigResponse, AmmResponse};
+use cosmwasm_std::{Addr, Deps, StdError, StdResult};
+use margined_perp::margined_insurance_fund::{AmmResponse, ConfigResponse};
 
-use crate::state::{read_config,Config, read_vamm};
+use crate::state::{read_config, read_vamm, Config};
 
 /// Queries contract Config
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
@@ -16,15 +16,15 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 pub fn query_amm(deps: Deps, amm: Addr) -> StdResult<AmmResponse> {
     let amm_list = read_vamm(deps.storage)?.vamms;
 
-    let amm_new: Addr = if amm_list.contains(&amm) { 
+    let amm_new: Addr = if amm_list.contains(&amm) {
         amm
     } else {
-        return Err(StdError::NotFound { kind: "AMM".to_string() })
+        return Err(StdError::NotFound {
+            kind: "AMM".to_string(),
+        });
     };
 
-    Ok(AmmResponse {
-        amm: amm_new
-    })
+    Ok(AmmResponse { amm: amm_new })
 }
 
 //Queries all of the current AMMs

--- a/contracts/margined_insurance_fund/src/query.rs
+++ b/contracts/margined_insurance_fund/src/query.rs
@@ -1,0 +1,30 @@
+use cosmwasm_std::{Deps, StdResult, Addr, StdError};
+use margined_perp::margined_insurance_fund::{ConfigResponse, AmmResponse};
+
+use crate::state::{read_config,Config, read_vamm};
+
+/// Queries contract Config
+pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config: Config = read_config(deps.storage)?;
+
+    Ok(ConfigResponse {
+        owner: config.owner,
+    })
+}
+
+///Queries the AMM with given address
+pub fn query_amm(deps: Deps, amm: Addr) -> StdResult<AmmResponse> {
+    let amm_list = read_vamm(deps.storage)?.vamms;
+
+    let amm_new: Addr = if amm_list.contains(&amm) { 
+        amm
+    } else {
+        return Err(StdError::NotFound { kind: "AMM".to_string() })
+    };
+
+    Ok(AmmResponse {
+        amm: amm_new
+    })
+}
+
+//Queries all of the current AMMs

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Api, DepsMut, StdResult, Storage, StdError};
+use cosmwasm_std::{Addr, Api, DepsMut, StdError, StdResult, Storage};
 use cosmwasm_storage::{singleton, singleton_read};
 use cw_storage_plus::Item; //, Map
 
@@ -43,7 +43,11 @@ pub fn remove_vamm(deps: DepsMut, input: Addr) -> StdResult<()> {
     // find the index (possible that the data isn't in the vec) and swap_remove it
     let index = match amm_list.vamms.iter().position(|x| x.eq(&input)) {
         Some(value) => value,
-        None => return Err(StdError::NotFound{kind: "AMM".to_string()}),
+        None => {
+            return Err(StdError::NotFound {
+                kind: "AMM".to_string(),
+            })
+        }
     };
     amm_list.vamms.swap_remove(index);
 

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -1,0 +1,57 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Addr, StdResult, Storage, DepsMut, Api};
+use cosmwasm_storage::{singleton, singleton_read};
+use cw_storage_plus::Item;
+
+pub static KEY_CONFIG: &[u8] = b"config";
+pub const VAMM_LIST: Item<VammList> = Item::new("vamm-list");
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct VammList {
+    pub vamms: Vec<Addr>,
+}
+
+impl VammList {
+    /// returns true if the address is a registered vamm
+    pub fn is_vamm(&self, addr: &str) -> bool {
+        self.vamms.iter().any(|a| a.as_ref() == addr)
+    }
+}
+
+pub fn save_vamm(deps: DepsMut, input: Addr) -> StdResult<()> {
+    let mut amm_list = VAMM_LIST.load(deps.storage)?;
+    amm_list.vamms.push(input);
+
+    VAMM_LIST.save(deps.storage, &amm_list)
+}
+
+pub fn read_vamm(storage: &dyn Storage) -> StdResult<VammList> {
+    VAMM_LIST.load(storage)
+}
+
+pub fn map_validate(api: &dyn Api, input: &[String]) -> StdResult<Vec<Addr>> {
+    input.iter().map(|addr| api.addr_validate(addr)).collect()
+}
+
+pub fn store_vamm(deps: DepsMut, input: &[String]) -> StdResult<()> {
+    let cfg = VammList {
+        vamms: map_validate(deps.api, input)?,
+    };
+    VAMM_LIST.save(deps.storage, &cfg)
+}
+
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub owner: Addr,
+}
+
+pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {
+    singleton(storage, KEY_CONFIG).save(config)
+}
+
+pub fn read_config(storage: &dyn Storage) -> StdResult<Config> {
+    singleton_read(storage, KEY_CONFIG).load()
+}

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -13,7 +13,7 @@ pub struct VammList {
     pub vamms: Vec<Addr>,
 }
 
-/* 
+/*
 impl VammList {
     /// returns true if the address is a registered vamm
     pub fn is_vamm(&self, addr: &str) -> bool {
@@ -60,7 +60,7 @@ pub fn read_vamm(storage: &dyn Storage) -> StdResult<VammList> {
     VAMM_LIST.load(storage)
 }
 
-/* 
+/*
 pub fn map_validate(api: &dyn Api, input: &[String]) -> StdResult<Vec<Addr>> {
     input.iter().map(|addr| api.addr_validate(addr)).collect()
 }

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -39,44 +39,6 @@ pub fn delist_vamm(deps: DepsMut, input: Addr) -> StdResult<()> {
     VAMM_LIST.remove(deps.storage, input);
     Ok(())
 }
-
-/*
-// function changes the bool stored under an address to 'false'
-// note that that means this can only be given an *existing* vamm
-pub fn vamm_off(deps: DepsMut, input: Addr) -> StdResult<()> {
-    // first check that there is data there
-    if VAMM_LIST.may_load(deps.storage, input.clone())?.is_none() {
-        return Err(StdError::GenericErr {
-            msg: "This vAMM has not been added".to_string(),
-        })
-    };
-    VAMM_LIST.save(deps.storage, input, &false)
-}
-
-// this function reads the bool stored under an addr, and if there is no addr stored there then throws an error
-// use this function when you want to check the 'on/off' status of a vAmm
-pub fn read_vamm(storage: &dyn Storage, input: Addr) -> StdResult<bool> {
-    VAMM_LIST
-        .load(storage, input)
-        .map_err(|_e| StdError::GenericErr {
-            msg: "No vAMM stored".to_string(),
-        })
-}
-*/
-
-//TODO Need to rewrite these fn to work with a Map instead of Vec
-/*
-pub fn map_validate(api: &dyn Api, input: &[String]) -> StdResult<Vec<Addr>> {
-    input.iter().map(|addr| api.addr_validate(addr)).collect()
-}
-
-pub fn store_vamm(deps: DepsMut, input: &[String]) -> StdResult<()> {
-    let cfg = VammList {
-        vamms: map_validate(deps.api, input)?,
-    };
-    VAMM_LIST.save(deps.storage, &cfg)
-}
-*/
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: Addr,

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Api, DepsMut, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, DepsMut, StdError, StdResult, Storage}; // Api,
 use cosmwasm_storage::{singleton, singleton_read};
 use cw_storage_plus::Item; //, Map
 

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -27,7 +27,7 @@ pub fn is_vamm(storage: &dyn Storage, input: Addr) -> bool {
 }
 
 // this function deletes the entry under the given key
-pub fn delist_vamm(deps: DepsMut, input: Addr) -> StdResult<()> {
+pub fn remove_amm(deps: DepsMut, input: Addr) -> StdResult<()> {
     // first check that there is data there
     if VAMM_LIST.may_load(deps.storage, input.clone())?.is_none() {
         return Err(StdError::GenericErr {

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -13,12 +13,14 @@ pub struct VammList {
     pub vamms: Vec<Addr>,
 }
 
+/* 
 impl VammList {
     /// returns true if the address is a registered vamm
     pub fn is_vamm(&self, addr: &str) -> bool {
         self.vamms.iter().any(|a| a.as_ref() == addr)
     }
 }
+*/
 
 // function saves a given Addr by either pushing it into the existing Vec or instantiating a new Vec
 
@@ -58,6 +60,7 @@ pub fn read_vamm(storage: &dyn Storage) -> StdResult<VammList> {
     VAMM_LIST.load(storage)
 }
 
+/* 
 pub fn map_validate(api: &dyn Api, input: &[String]) -> StdResult<Vec<Addr>> {
     input.iter().map(|addr| api.addr_validate(addr)).collect()
 }
@@ -68,7 +71,7 @@ pub fn store_vamm(deps: DepsMut, input: &[String]) -> StdResult<()> {
     };
     VAMM_LIST.save(deps.storage, &cfg)
 }
-
+*/
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: Addr,

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -13,13 +13,10 @@ pub fn save_vamm(deps: DepsMut, input: Addr) -> StdResult<()> {
     // we match because the data might not exist yet
     // In the case there is data, we force an error
     // In the case there is not data, we add the Addr and set its bool to true
-    match VAMM_LIST.may_load(deps.storage, input.clone())? {
-        Some(_is_vamm) => {
-            return Err(StdError::GenericErr {
-                msg: "This vAMM is already added".to_string(),
-            })
-        }
-        None => {}
+    if let Some(_is_vamm) = VAMM_LIST.may_load(deps.storage, input.clone())? {
+        return Err(StdError::GenericErr {
+            msg: "This vAMM is already added".to_string(),
+        });
     };
     VAMM_LIST.save(deps.storage, input, &true)
 }
@@ -32,29 +29,26 @@ pub fn is_vamm(storage: &dyn Storage, input: Addr) -> bool {
 // this function deletes the entry under the given key
 pub fn delist_vamm(deps: DepsMut, input: Addr) -> StdResult<()> {
     // first check that there is data there
-    match VAMM_LIST.may_load(deps.storage, input.clone())? {
-        Some(_is_vamm) => {}
-        None => {
-            return Err(StdError::GenericErr {
-                msg: "This vAMM has not been added".to_string(),
-            })
-        }
+    if VAMM_LIST.may_load(deps.storage, input.clone())?.is_none() {
+        return Err(StdError::GenericErr {
+            msg: "This vAMM has not been added".to_string(),
+        });
     };
+
     // removes the entry from the Map
-    Ok(VAMM_LIST.remove(deps.storage, input))
+    VAMM_LIST.remove(deps.storage, input);
+    Ok(())
 }
 
+/*
 // function changes the bool stored under an address to 'false'
 // note that that means this can only be given an *existing* vamm
 pub fn vamm_off(deps: DepsMut, input: Addr) -> StdResult<()> {
     // first check that there is data there
-    match VAMM_LIST.may_load(deps.storage, input.clone())? {
-        Some(_is_vamm) => {}
-        None => {
-            return Err(StdError::GenericErr {
-                msg: "This vAMM has not been added".to_string(),
-            })
-        }
+    if VAMM_LIST.may_load(deps.storage, input.clone())?.is_none() {
+        return Err(StdError::GenericErr {
+            msg: "This vAMM has not been added".to_string(),
+        })
     };
     VAMM_LIST.save(deps.storage, input, &false)
 }
@@ -68,7 +62,9 @@ pub fn read_vamm(storage: &dyn Storage, input: Addr) -> StdResult<bool> {
             msg: "No vAMM stored".to_string(),
         })
 }
+*/
 
+//TODO Need to rewrite these fn to work with a Map instead of Vec
 /*
 pub fn map_validate(api: &dyn Api, input: &[String]) -> StdResult<Vec<Addr>> {
     input.iter().map(|addr| api.addr_validate(addr)).collect()

--- a/contracts/margined_insurance_fund/src/testing/mod.rs
+++ b/contracts/margined_insurance_fund/src/testing/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -1,29 +1,21 @@
-use crate::{
-    contract::{execute, instantiate, query},
+use crate::contract::{execute, instantiate, query};
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{from_binary, Addr, StdError};
+use margined_perp::margined_insurance_fund::{
+    AmmResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg,
 };
-use cosmwasm_std::{from_binary, Addr};
-use cosmwasm_std::{
-    testing::{mock_dependencies, mock_env, mock_info},
-};
-use margined_perp::margined_insurance_fund::{ConfigResponse, AmmResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 #[test]
 fn test_instantiation() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
     let config: ConfigResponse = from_binary(&res).unwrap();
     let info = mock_info("addr0000", &[]);
-    assert_eq!(
-        config,
-        ConfigResponse {
-            owner: info.sender,
-        }
-    );
+    assert_eq!(config, ConfigResponse { owner: info.sender });
 }
 
 #[test]
@@ -68,13 +60,23 @@ fn query_amm() {
     execute(deps.as_mut(), mock_env(), info, msg);
 
     //check for the added AMM
-    let res = query(deps.as_ref(), mock_env(), QueryMsg::GetAMM { amm: Addr::unchecked("addr0001".to_string()) }).unwrap();
-    let amm: AmmResponse = from_binary(&res).unwrap();
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GetAMM {
+            amm: Addr::unchecked("addr0001".to_string()),
+        },
+    )
+    .unwrap();
 
+    let amm: AmmResponse = from_binary(&res).unwrap();
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    assert_eq!(amm, AmmResponse {amm: addr1});
 }
 
 #[test]
-fn query_all_amm(){
+fn query_all_amm() {
     //instantiate contract here
 
     //check to see that there are no AMMs
@@ -87,23 +89,99 @@ fn query_all_amm(){
 #[test]
 fn add_amm() {
     //instantiate contract here
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {};
+    let info = mock_info("addr0000", &[]);
 
-    //check to see that there are no AMMs
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    //query the AMM we want to add
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GetAMM {
+            amm: Addr::unchecked("addr0001".to_string()),
+        },
+    );
+
+    let e_no_amm = Err(StdError::NotFound { kind: "margined_insurance_fund::state::VammList".to_string()});
+    assert_eq!(res, e_no_amm);
 
     //add an AMM
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+
+    execute(deps.as_mut(), mock_env(), info, msg);
 
     //check for the added AMM
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GetAMM {
+            amm: Addr::unchecked("addr0001".to_string()),
+        },
+    )
+    .unwrap();
+
+    let amm: AmmResponse = from_binary(&res).unwrap();
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    assert_eq!(amm, AmmResponse {amm: addr1});
 }
 
 #[test]
-fn remove_amm(){
+fn remove_amm() {
     //instantiate contract here
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {};
+    let info = mock_info("addr0000", &[]);
+
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //add an AMM
-    
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+
+    execute(deps.as_mut(), mock_env(), info, msg);
+
     //check to see that there is one AMM
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GetAMM {
+            amm: Addr::unchecked("addr0001".to_string()),
+        },
+    )
+    .unwrap();
+
+    let amm: AmmResponse = from_binary(&res).unwrap();
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    assert_eq!(amm, AmmResponse {amm: addr1});
 
     //remove an AMM
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::RemoveAMM { amm:  addr1 };
+
+    execute(deps.as_mut(), mock_env(), info, msg);
 
     //check that there are zero AMMs
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GetAMM {
+            amm: Addr::unchecked("addr0001".to_string()),
+        },
+    );
+
+    let e_no_amm = Err(StdError::NotFound { kind: "AMM".to_string()});
+
+    assert_eq!(res, e_no_amm);
+
 }

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -57,7 +57,7 @@ fn query_amm() {
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::AddAMM { amm: addr1 };
 
-    execute(deps.as_mut(), mock_env(), info, msg);
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //check for the added AMM
     let res = query(
@@ -115,7 +115,7 @@ fn add_amm() {
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::AddAMM { amm: addr1 };
 
-    execute(deps.as_mut(), mock_env(), info, msg);
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //check for the added AMM
     let res = query(
@@ -148,7 +148,7 @@ fn remove_amm() {
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::AddAMM { amm: addr1 };
 
-    execute(deps.as_mut(), mock_env(), info, msg);
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //check to see that there is one AMM
     let res = query(
@@ -171,7 +171,7 @@ fn remove_amm() {
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::RemoveAMM { amm: addr1 };
 
-    execute(deps.as_mut(), mock_env(), info, msg);
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //check that there are zero AMMs
     let res = query(

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -70,9 +70,10 @@ fn query_amm() {
     .unwrap();
 
     let res: AmmResponse = from_binary(&res).unwrap();
+    let amm_addr = res.amm;
     let addr1 = "addr0001".to_string();
 
-    assert_eq!(res.amm.to_string(), addr1);
+    assert_eq!(amm_addr.to_string(), addr1);
 }
 
 #[test]
@@ -130,9 +131,10 @@ fn add_amm() {
     .unwrap();
 
     let res: AmmResponse = from_binary(&res).unwrap();
+    let amm_addr = res.amm;
     let addr1 = "addr0001".to_string();
 
-    assert_eq!(res.amm.to_string(), addr1);
+    assert_eq!(amm_addr.to_string(), addr1);
 }
 
 #[test]
@@ -173,9 +175,10 @@ fn add_second_amm() {
     .unwrap();
 
     let res: AmmResponse = from_binary(&res).unwrap();
+    let amm_addr = res.amm;
     let addr2 = "addr0002".to_string();
 
-    assert_eq!(res.amm.to_string(), addr2);
+    assert_eq!(amm_addr.to_string(), addr2);
 }
 #[test]
 fn index_error() {
@@ -238,9 +241,10 @@ fn remove_amm() {
     .unwrap();
 
     let res: AmmResponse = from_binary(&res).unwrap();
+    let amm_addr = res.amm;
     let addr1 = "addr0001".to_string();
 
-    assert_eq!(res.amm.to_string(), addr1);
+    assert_eq!(amm_addr.to_string(), addr1);
 
     //remove an AMM
     let addr1 = "addr0001".to_string();

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -2,7 +2,7 @@ use crate::contract::{execute, instantiate, query};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{from_binary, Addr, StdError};
 use margined_perp::margined_insurance_fund::{
-    AmmResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg,
+    ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VammResponse,
 };
 
 #[test]
@@ -43,7 +43,7 @@ fn test_update_config() {
     );
 }
 #[test]
-fn query_amm() {
+fn query_vamm_test() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -51,46 +51,45 @@ fn query_amm() {
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //add an AMM
+    //add an vAMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr1 };
+    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //check for the added AMM
+    //check for the added vAMM
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0001".to_string(),
+        QueryMsg::IsVamm {
+            vamm: "addr0001".to_string(),
         },
     )
     .unwrap();
 
-    let res: AmmResponse = from_binary(&res).unwrap();
-    let amm_addr = res.amm;
-    let addr1 = "addr0001".to_string();
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
 
-    assert_eq!(amm_addr.to_string(), addr1);
+    assert_eq!(is_vamm, true);
 }
 
 #[test]
-fn query_all_amm() {
+fn query_all_vamm_test() {
     //instantiate contract here
 
-    //check to see that there are no AMMs
+    //check to see that there are no vAMMs
 
-    //add an AMM
+    //add an vAMM
 
-    //add another AMM
+    //add another vAMM
 
-    //check for the added AMMs
+    //check for the added vAMMs
 }
 
 #[test]
-fn add_amm() {
+fn add_vamm_test() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -98,48 +97,48 @@ fn add_amm() {
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //query the AMM we want to add
+    //query the vAMM we want to add
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0001".to_string(),
-        },
-    );
-
-    let e_no_amm = Err(StdError::NotFound {
-        kind: "margined_insurance_fund::state::VammList".to_string(),
-    });
-    assert_eq!(res, e_no_amm);
-
-    //add an AMM
-    let addr1 = "addr0001".to_string();
-
-    let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr1 };
-
-    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    //check for the added AMM
-    let res = query(
-        deps.as_ref(),
-        mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0001".to_string(),
+        QueryMsg::IsVamm {
+            vamm: "addr0001".to_string(),
         },
     )
     .unwrap();
 
-    let res: AmmResponse = from_binary(&res).unwrap();
-    let amm_addr = res.amm;
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
+
+    assert_eq!(is_vamm, false);
+
+    //add an vAMM
     let addr1 = "addr0001".to_string();
 
-    assert_eq!(amm_addr.to_string(), addr1);
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
+
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    //check for the added vAMM
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::IsVamm {
+            vamm: "addr0001".to_string(),
+        },
+    )
+    .unwrap();
+
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
+
+    assert_eq!(is_vamm, true);
 }
 
 #[test]
-fn add_second_amm() {
-    // this tests for adding a second AMM, to ensure the 'push' match arm of save_amm is used
+fn add_second_vamm_test() {
+    // this tests for adding a second vAMM, to ensure the 'push' match arm of save_vamm is used
 
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
@@ -148,38 +147,40 @@ fn add_second_amm() {
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //add first AMM
+    //add first vAMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr1 };
+    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //add second AMM
+    //add second vAMM
     let addr2 = "addr0002".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr2 };
+    let msg = ExecuteMsg::AddVamm { vamm: addr2 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //check for the second added AMM
+    //check for the second added vAMM
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0002".to_string(),
+        QueryMsg::IsVamm {
+            vamm: "addr0002".to_string(),
         },
     )
     .unwrap();
 
-    let res: AmmResponse = from_binary(&res).unwrap();
-    let amm_addr = res.amm;
-    let addr2 = "addr0002".to_string();
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
 
-    assert_eq!(amm_addr.to_string(), addr2);
+    assert_eq!(is_vamm, true);
 }
+
+// tentatively say, we don't need this test anymore
+/*
 #[test]
 fn index_error() {
     //This tests for the case where some data is stored, but not the right data (the index won't be found)
@@ -191,30 +192,33 @@ fn index_error() {
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //add first AMM
+    //add first vAMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr1 };
+    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //check for a second AMM
+    //check for a second vAMM
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0002".to_string(),
+        QueryMsg::IsVamm {
+            vamm: "addr0002".to_string(),
         },
-    );
+    )
+    .unwrap();
 
-    let res = res.unwrap_err();
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
 
-    assert_eq!(res.to_string(), "AMM not found");
+    assert_eq!(is_vamm, false);
 }
+*/
 
 #[test]
-fn remove_amm() {
+fn remove_vamm_test() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -222,35 +226,34 @@ fn remove_amm() {
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //add an AMM
+    //add an vAMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr1 };
+    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    //check to see that there is one AMM
+    //check to see that there is one vAMM
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0001".to_string(),
+        QueryMsg::IsVamm {
+            vamm: "addr0001".to_string(),
         },
     )
     .unwrap();
 
-    let res: AmmResponse = from_binary(&res).unwrap();
-    let amm_addr = res.amm;
-    let addr1 = "addr0001".to_string();
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
 
-    assert_eq!(amm_addr.to_string(), addr1);
+    assert_eq!(is_vamm, true);
 
     //remove an AMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::RemoveAmm { amm: addr1 };
+    let msg = ExecuteMsg::RemoveVamm { vamm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -258,20 +261,20 @@ fn remove_amm() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAmm {
-            amm: "addr0001".to_string(),
+        QueryMsg::IsVamm {
+            vamm: "addr0001".to_string(),
         },
-    );
+    )
+    .unwrap();
 
-    let e_no_amm = Err(StdError::NotFound {
-        kind: "AMM".to_string(),
-    });
+    let res: VammResponse = from_binary(&res).unwrap();
+    let is_vamm = res.is_vamm;
 
-    assert_eq!(res, e_no_amm);
+    assert_eq!(is_vamm, false);
 }
 
 #[test]
-fn not_owner() {
+fn not_owner_test() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -290,21 +293,21 @@ fn not_owner() {
 
     assert_eq!(res.to_string(), "Unauthorized");
 
-    // try to add an AMM
+    // try to add a vAMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("not_the_owner", &[]);
-    let msg = ExecuteMsg::AddAmm { amm: addr1 };
+    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 
     assert_eq!(res.to_string(), "Unauthorized");
 
-    //try to remove an AMM
+    //try to remove an vAMM
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("not_the_owner", &[]);
-    let msg = ExecuteMsg::RemoveAmm { amm: addr1 };
+    let msg = ExecuteMsg::RemoveVamm { vamm: addr1 };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -1,6 +1,6 @@
 use crate::contract::{execute, instantiate, query};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Addr, StdError};
+use cosmwasm_std::{from_binary, Addr};
 use margined_perp::margined_insurance_fund::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VammResponse,
 };

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -43,7 +43,7 @@ fn test_update_config() {
     );
 }
 #[test]
-fn query_vamm_test() {
+fn test_query_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -76,7 +76,7 @@ fn query_vamm_test() {
 }
 
 #[test]
-fn query_all_vamm_test() {
+fn test_query_all_vamm() {
     //instantiate contract here
 
     //check to see that there are no vAMMs
@@ -89,7 +89,7 @@ fn query_all_vamm_test() {
 }
 
 #[test]
-fn add_vamm_test() {
+fn test_add_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -137,7 +137,7 @@ fn add_vamm_test() {
 }
 
 #[test]
-fn add_second_vamm_test() {
+fn test_add_second_vamm() {
     // this tests for adding a second vAMM, to ensure the 'push' match arm of save_vamm is used
 
     //instantiate contract here
@@ -179,46 +179,8 @@ fn add_second_vamm_test() {
     assert_eq!(is_vamm, true);
 }
 
-// tentatively say, we don't need this test anymore
-/*
 #[test]
-fn index_error() {
-    //This tests for the case where some data is stored, but not the right data (the index won't be found)
-
-    //instantiate contract here
-    let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
-    let info = mock_info("addr0000", &[]);
-
-    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    //add first vAMM
-    let addr1 = "addr0001".to_string();
-
-    let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddVamm { vamm: addr1 };
-
-    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    //check for a second vAMM
-    let res = query(
-        deps.as_ref(),
-        mock_env(),
-        QueryMsg::IsVamm {
-            vamm: "addr0002".to_string(),
-        },
-    )
-    .unwrap();
-
-    let res: VammResponse = from_binary(&res).unwrap();
-    let is_vamm = res.is_vamm;
-
-    assert_eq!(is_vamm, false);
-}
-*/
-
-#[test]
-fn remove_vamm_test() {
+fn test_remove_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};
@@ -274,7 +236,7 @@ fn remove_vamm_test() {
 }
 
 #[test]
-fn not_owner_test() {
+fn test_not_owner() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {};

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -72,7 +72,7 @@ fn query_amm() {
     let amm: AmmResponse = from_binary(&res).unwrap();
     let addr1 = Addr::unchecked("addr0001".to_string());
 
-    assert_eq!(amm, AmmResponse {amm: addr1});
+    assert_eq!(amm, AmmResponse { amm: addr1 });
 }
 
 #[test]
@@ -104,7 +104,9 @@ fn add_amm() {
         },
     );
 
-    let e_no_amm = Err(StdError::NotFound { kind: "margined_insurance_fund::state::VammList".to_string()});
+    let e_no_amm = Err(StdError::NotFound {
+        kind: "margined_insurance_fund::state::VammList".to_string(),
+    });
     assert_eq!(res, e_no_amm);
 
     //add an AMM
@@ -128,7 +130,7 @@ fn add_amm() {
     let amm: AmmResponse = from_binary(&res).unwrap();
     let addr1 = Addr::unchecked("addr0001".to_string());
 
-    assert_eq!(amm, AmmResponse {amm: addr1});
+    assert_eq!(amm, AmmResponse { amm: addr1 });
 }
 
 #[test]
@@ -161,13 +163,13 @@ fn remove_amm() {
     let amm: AmmResponse = from_binary(&res).unwrap();
     let addr1 = Addr::unchecked("addr0001".to_string());
 
-    assert_eq!(amm, AmmResponse {amm: addr1});
+    assert_eq!(amm, AmmResponse { amm: addr1 });
 
     //remove an AMM
     let addr1 = Addr::unchecked("addr0001".to_string());
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::RemoveAMM { amm:  addr1 };
+    let msg = ExecuteMsg::RemoveAMM { amm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg);
 
@@ -180,8 +182,9 @@ fn remove_amm() {
         },
     );
 
-    let e_no_amm = Err(StdError::NotFound { kind: "AMM".to_string()});
+    let e_no_amm = Err(StdError::NotFound {
+        kind: "AMM".to_string(),
+    });
 
     assert_eq!(res, e_no_amm);
-
 }

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -1,0 +1,109 @@
+use crate::{
+    contract::{execute, instantiate, query},
+};
+use cosmwasm_std::{from_binary, Addr};
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, mock_info},
+};
+use margined_perp::margined_insurance_fund::{ConfigResponse, AmmResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+
+#[test]
+fn test_instantiation() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
+    let config: ConfigResponse = from_binary(&res).unwrap();
+    let info = mock_info("addr0000", &[]);
+    assert_eq!(
+        config,
+        ConfigResponse {
+            owner: info.sender,
+        }
+    );
+}
+
+#[test]
+fn test_update_config() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {};
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // Update the config
+    let msg = ExecuteMsg::UpdateConfig {
+        owner: Some("addr0001".to_string()),
+    };
+
+    let info = mock_info("addr0000", &[]);
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
+    let config: ConfigResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        config,
+        ConfigResponse {
+            owner: Addr::unchecked("addr0001".to_string()),
+        }
+    );
+}
+#[test]
+fn query_amm() {
+    //instantiate contract here
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {};
+    let info = mock_info("addr0000", &[]);
+
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    //add an AMM
+    let addr1 = Addr::unchecked("addr0001".to_string());
+
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+
+    execute(deps.as_mut(), mock_env(), info, msg);
+
+    //check for the added AMM
+    let res = query(deps.as_ref(), mock_env(), QueryMsg::GetAMM { amm: Addr::unchecked("addr0001".to_string()) }).unwrap();
+    let amm: AmmResponse = from_binary(&res).unwrap();
+
+}
+
+#[test]
+fn query_all_amm(){
+    //instantiate contract here
+
+    //check to see that there are no AMMs
+
+    //add an AMM
+
+    //check for the added AMM
+}
+
+#[test]
+fn add_amm() {
+    //instantiate contract here
+
+    //check to see that there are no AMMs
+
+    //add an AMM
+
+    //check for the added AMM
+}
+
+#[test]
+fn remove_amm(){
+    //instantiate contract here
+
+    //add an AMM
+    
+    //check to see that there is one AMM
+
+    //remove an AMM
+
+    //check that there are zero AMMs
+}

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -55,7 +55,7 @@ fn query_amm() {
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+    let msg = ExecuteMsg::AddAmm { amm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -63,7 +63,7 @@ fn query_amm() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAMM {
+        QueryMsg::GetAmm {
             amm: "addr0001".to_string(),
         },
     )
@@ -99,7 +99,7 @@ fn add_amm() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAMM {
+        QueryMsg::GetAmm {
             amm: "addr0001".to_string(),
         },
     );
@@ -113,7 +113,7 @@ fn add_amm() {
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+    let msg = ExecuteMsg::AddAmm { amm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -121,7 +121,7 @@ fn add_amm() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAMM {
+        QueryMsg::GetAmm {
             amm: "addr0001".to_string(),
         },
     )
@@ -146,7 +146,7 @@ fn add_two_amms() {
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+    let msg = ExecuteMsg::AddAmm { amm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -154,7 +154,7 @@ fn add_two_amms() {
     let addr2 = "addr0002".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAMM { amm: addr2 };
+    let msg = ExecuteMsg::AddAmm { amm: addr2 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -162,7 +162,7 @@ fn add_two_amms() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAMM {
+        QueryMsg::GetAmm {
             amm: "addr0002".to_string(),
         },
     )
@@ -187,7 +187,7 @@ fn remove_amm() {
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+    let msg = ExecuteMsg::AddAmm { amm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -195,7 +195,7 @@ fn remove_amm() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAMM {
+        QueryMsg::GetAmm {
             amm: "addr0001".to_string(),
         },
     )
@@ -210,7 +210,7 @@ fn remove_amm() {
     let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
-    let msg = ExecuteMsg::RemoveAMM { amm: addr1 };
+    let msg = ExecuteMsg::RemoveAmm { amm: addr1 };
 
     execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -218,7 +218,7 @@ fn remove_amm() {
     let res = query(
         deps.as_ref(),
         mock_env(),
-        QueryMsg::GetAMM {
+        QueryMsg::GetAmm {
             amm: "addr0001".to_string(),
         },
     );

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -52,7 +52,7 @@ fn query_amm() {
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //add an AMM
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::AddAMM { amm: addr1 };
@@ -64,15 +64,15 @@ fn query_amm() {
         deps.as_ref(),
         mock_env(),
         QueryMsg::GetAMM {
-            amm: Addr::unchecked("addr0001".to_string()),
+            amm: "addr0001".to_string(),
         },
     )
     .unwrap();
 
-    let amm: AmmResponse = from_binary(&res).unwrap();
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let res: AmmResponse = from_binary(&res).unwrap();
+    let addr1 = "addr0001".to_string();
 
-    assert_eq!(amm, AmmResponse { amm: addr1 });
+    assert_eq!(res.amm.to_string(), addr1);
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn add_amm() {
         deps.as_ref(),
         mock_env(),
         QueryMsg::GetAMM {
-            amm: Addr::unchecked("addr0001".to_string()),
+            amm: "addr0001".to_string(),
         },
     );
 
@@ -110,7 +110,7 @@ fn add_amm() {
     assert_eq!(res, e_no_amm);
 
     //add an AMM
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::AddAMM { amm: addr1 };
@@ -122,15 +122,56 @@ fn add_amm() {
         deps.as_ref(),
         mock_env(),
         QueryMsg::GetAMM {
-            amm: Addr::unchecked("addr0001".to_string()),
+            amm: "addr0001".to_string(),
         },
     )
     .unwrap();
 
-    let amm: AmmResponse = from_binary(&res).unwrap();
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let res: AmmResponse = from_binary(&res).unwrap();
+    let addr1 = "addr0001".to_string();
 
-    assert_eq!(amm, AmmResponse { amm: addr1 });
+    assert_eq!(res.amm.to_string(), addr1);
+}
+
+#[test]
+fn add_two_amms() {
+    //instantiate contract here
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {};
+    let info = mock_info("addr0000", &[]);
+
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    //add first AMM
+    let addr1 = "addr0001".to_string();
+
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::AddAMM { amm: addr1 };
+
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    //add second AMM
+    let addr2 = "addr0002".to_string();
+
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::AddAMM { amm: addr2 };
+
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    //check for the second added AMM
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GetAMM {
+            amm: "addr0002".to_string(),
+        },
+    )
+    .unwrap();
+
+    let res: AmmResponse = from_binary(&res).unwrap();
+    let addr2 = "addr0002".to_string();
+
+    assert_eq!(res.amm.to_string(), addr2);
 }
 
 #[test]
@@ -143,7 +184,7 @@ fn remove_amm() {
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     //add an AMM
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::AddAMM { amm: addr1 };
@@ -155,18 +196,18 @@ fn remove_amm() {
         deps.as_ref(),
         mock_env(),
         QueryMsg::GetAMM {
-            amm: Addr::unchecked("addr0001".to_string()),
+            amm: "addr0001".to_string(),
         },
     )
     .unwrap();
 
-    let amm: AmmResponse = from_binary(&res).unwrap();
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let res: AmmResponse = from_binary(&res).unwrap();
+    let addr1 = "addr0001".to_string();
 
-    assert_eq!(amm, AmmResponse { amm: addr1 });
+    assert_eq!(res.amm.to_string(), addr1);
 
     //remove an AMM
-    let addr1 = Addr::unchecked("addr0001".to_string());
+    let addr1 = "addr0001".to_string();
 
     let info = mock_info("addr0000", &[]);
     let msg = ExecuteMsg::RemoveAMM { amm: addr1 };
@@ -178,7 +219,7 @@ fn remove_amm() {
         deps.as_ref(),
         mock_env(),
         QueryMsg::GetAMM {
-            amm: Addr::unchecked("addr0001".to_string()),
+            amm: "addr0001".to_string(),
         },
     );
 

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -205,7 +205,7 @@ fn index_error() {
         },
     );
 
-    let res =  res.unwrap_err();
+    let res = res.unwrap_err();
 
     assert_eq!(res.to_string(), "AMM not found");
 }

--- a/packages/margined_perp/src/lib.rs
+++ b/packages/margined_perp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod margined_engine;
+pub mod margined_insurance_fund;
 pub mod margined_pricefeed;
 pub mod margined_vamm;
 pub mod querier;

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -1,26 +1,31 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::Addr;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-}
+pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    UpdateConfig {
-        owner: Option<String>,
-    },
+    UpdateConfig { owner: Option<String> },
+    AddAMM { amm: Addr },
+    RemoveAMM { amm: Addr },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Config {},
+    GetAMM { amm: Addr },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
     pub owner: Addr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AmmResponse {
+    pub amm: Addr,
 }

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -1,0 +1,26 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Addr, Uint128};
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    UpdateConfig {
+        owner: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Config {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub owner: Addr,
+}

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -9,15 +9,15 @@ pub struct InstantiateMsg {}
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     UpdateConfig { owner: Option<String> },
-    AddAmm { amm: String },
-    RemoveAmm { amm: String },
+    AddVamm { vamm: String },
+    RemoveVamm { vamm: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Config {},
-    GetAmm { amm: String },
+    IsVamm { vamm: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -26,6 +26,6 @@ pub struct ConfigResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct AmmResponse {
-    pub amm: Addr,
+pub struct VammResponse {
+    pub is_vamm: bool,
 }

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -9,15 +9,15 @@ pub struct InstantiateMsg {}
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     UpdateConfig { owner: Option<String> },
-    AddAMM { amm: Addr },
-    RemoveAMM { amm: Addr },
+    AddAmm { amm: String },
+    RemoveAmm { amm: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Config {},
-    GetAMM { amm: Addr },
+    GetAmm { amm: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Beginnings of the Insurance Fund contract - so far have added:
- Query AMM function
- Add AMM function
- Remove AMM function

Not sure about the design of the adding/removing functions - both functions effectively just call a function from state.rs to do it when it could be rewritten to be done in a single place (idk if thats better or not tbh) 

Main issue is the storage of the vammlist as a vec - some downsides are:
1. Can add multiple of the same AMM 
2. finding an existing AMM requires iterating thru the vec to find index (gas cost might be high?) 

Other smaller issues are maybe naming consistency (amm vs vamm, similarity in function names) and could improve error handling (specifically line 107 of tests.rs - the error actually arises from there being no amm saved, but the error message isn't clear)

TODO:
1. Change to a MAP instead of Vec in ITEM 
2. Add a query all function