### PR TITLE
Feature/insurance-fund-withdraw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,9 +574,11 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus 0.8.1",
+ "cw20 0.9.1",
  "margined_perp",
  "schemars",
  "serde",
+ "terraswap",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "cw20-base",
  "margined_common",
  "margined_engine",
+ "margined_insurance_fund",
  "margined_perp",
  "margined_pricefeed",
  "margined_vamm",

--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -386,7 +386,7 @@ pub fn withdraw_margin(
         env,
         &mut state,
         &trader,
-        &config.insurance_fund,
+        // &config.insurance_fund,
         config.eligible_collateral,
         amount,
     )

--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -386,7 +386,6 @@ pub fn withdraw_margin(
         env,
         &mut state,
         &trader,
-        // &config.insurance_fund,
         config.eligible_collateral,
         amount,
     )

--- a/contracts/margined_engine/src/messages.rs
+++ b/contracts/margined_engine/src/messages.rs
@@ -10,7 +10,7 @@ use crate::{
     state::{read_config, State},
 };
 
-use margined_perp::margined_insurance_fund::ExecuteMsg as InsuranceFundExectureMessage;
+use margined_perp::margined_insurance_fund::ExecuteMsg as InsuranceFundExecuteMessage;
 use margined_perp::margined_vamm::CalcFeeResponse;
 use margined_perp::querier::query_token_balance;
 
@@ -117,7 +117,7 @@ pub fn execute_insurance_fund_withdrawal(deps: Deps, amount: Uint128) -> StdResu
     let msg = WasmMsg::Execute {
         contract_addr: config.insurance_fund.to_string(),
         funds: vec![],
-        msg: to_binary(&InsuranceFundExectureMessage::Withdraw {
+        msg: to_binary(&InsuranceFundExecuteMessage::Withdraw {
             token: config.eligible_collateral,
             amount,
         })?,

--- a/contracts/margined_engine/src/messages.rs
+++ b/contracts/margined_engine/src/messages.rs
@@ -120,7 +120,6 @@ pub fn execute_insurance_fund_withdrawal(deps: Deps, amount: Uint128) -> StdResu
         msg: to_binary(&InsuranceFundExectureMessage::Withdraw {
             token: config.eligible_collateral,
             amount,
-            // amount: amount_to_send,
         })?,
     };
 

--- a/contracts/margined_engine/src/reply.rs
+++ b/contracts/margined_engine/src/reply.rs
@@ -539,7 +539,6 @@ pub fn partial_liquidation_reply(
             env.clone(),
             &mut state,
             &liquidator.unwrap(),
-            // &config.insurance_fund,
             config.eligible_collateral,
             liquidation_fee,
         )

--- a/contracts/margined_engine/src/reply.rs
+++ b/contracts/margined_engine/src/reply.rs
@@ -100,7 +100,6 @@ pub fn increase_position_reply(
                     env,
                     &mut state,
                     &swap.trader,
-                    // &config.insurance_fund,
                     config.eligible_collateral,
                     swap.margin_to_vault.value,
                 )
@@ -437,7 +436,6 @@ pub fn liquidate_reply(
             env.clone(),
             &mut state,
             &liquidator,
-            // &config.insurance_fund,
             config.eligible_collateral,
             liquidation_fee,
         )

--- a/contracts/margined_engine/src/testing/fee_calculation_tests.rs
+++ b/contracts/margined_engine/src/testing/fee_calculation_tests.rs
@@ -10,11 +10,11 @@ fn test_open_position_total_fee_ten_percent() {
         mut router,
         owner,
         alice,
-        insurance,
         usdc,
         fee_pool,
         engine,
         vamm,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -53,7 +53,9 @@ fn test_open_position_total_fee_ten_percent() {
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
     assert_eq!(fee_pool_balance, Uint128::from(30_000_000_000u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5030_000_000_000u128));
 }
 
@@ -63,11 +65,11 @@ fn test_open_short_position_twice_total_fee_ten_percent() {
         mut router,
         owner,
         alice,
-        insurance,
         usdc,
         fee_pool,
         engine,
         vamm,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -121,7 +123,9 @@ fn test_open_short_position_twice_total_fee_ten_percent() {
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
     assert_eq!(fee_pool_balance, Uint128::from(10_000_000_000u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5010_000_000_000u128));
 }
 
@@ -131,11 +135,11 @@ fn test_open_and_close_position_fee_ten_percent() {
         mut router,
         owner,
         alice,
-        insurance,
         usdc,
         fee_pool,
         engine,
         vamm,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -174,7 +178,9 @@ fn test_open_and_close_position_fee_ten_percent() {
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
     assert_eq!(fee_pool_balance, Uint128::from(60_000_000_000u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5060_000_000_000u128));
 }
 
@@ -184,11 +190,11 @@ fn test_open_position_close_manually_open_reverse_position_total_fee_ten_percent
         mut router,
         owner,
         alice,
-        insurance,
         usdc,
         fee_pool,
         engine,
         vamm,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -241,7 +247,9 @@ fn test_open_position_close_manually_open_reverse_position_total_fee_ten_percent
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
     assert_eq!(fee_pool_balance, Uint128::from(60_000_000_000u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5060_000_000_000u128));
 }
 
@@ -251,11 +259,11 @@ fn test_open_position_close_manually_open_reverse_position_short_then_long_total
         mut router,
         owner,
         alice,
-        insurance,
         usdc,
         fee_pool,
         engine,
         vamm,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -308,7 +316,9 @@ fn test_open_position_close_manually_open_reverse_position_short_then_long_total
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
     assert_eq!(fee_pool_balance, Uint128::from(60_000_000_000u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5060_000_000_000u128));
 }
 
@@ -441,11 +451,11 @@ fn test_has_spread_no_toll() {
         mut router,
         owner,
         alice,
-        insurance,
         usdc,
         fee_pool,
         engine,
         vamm,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -473,6 +483,8 @@ fn test_has_spread_no_toll() {
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
     assert_eq!(fee_pool_balance, Uint128::zero());
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5060_000_000_000u128));
 }

--- a/contracts/margined_engine/src/testing/liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/liquidation_tests.rs
@@ -14,11 +14,11 @@ fn test_partially_liquidate_long_position() {
         bob,
         carol,
         owner,
-        insurance,
         engine,
         usdc,
         vamm,
         pricefeed,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -136,7 +136,9 @@ fn test_partially_liquidate_long_position() {
     let carol_balance = usdc.balance(&router, carol.clone()).unwrap();
     assert_eq!(carol_balance, Uint128::from(855_695_509u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5_000_855_695_509u128));
 }
 
@@ -277,11 +279,11 @@ fn test_partially_liquidate_short_position() {
         bob,
         carol,
         owner,
-        insurance,
         engine,
         usdc,
         vamm,
         pricefeed,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -398,7 +400,9 @@ fn test_partially_liquidate_short_position() {
     let carol_balance = usdc.balance(&router, carol.clone()).unwrap();
     assert_eq!(carol_balance, Uint128::from(553_234_429u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(5_000_553_234_429u128));
 }
 
@@ -539,11 +543,11 @@ fn test_long_position_complete_liquidation() {
         bob,
         carol,
         owner,
-        insurance,
         engine,
         usdc,
         vamm,
         pricefeed,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -651,7 +655,9 @@ fn test_long_position_complete_liquidation() {
     assert_eq!(carol_balance, Uint128::from(2_801_120_448u128));
 
     // 5000 - 0.91 - 2.8
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(4_996_288_515_407u128));
 }
 
@@ -788,11 +794,11 @@ fn test_short_position_complete_liquidation() {
         bob,
         carol,
         owner,
-        insurance,
         engine,
         usdc,
         vamm,
         pricefeed,
+        insurance_fund,
         ..
     } = SimpleScenario::new();
 
@@ -900,7 +906,9 @@ fn test_short_position_complete_liquidation() {
     assert_eq!(carol_balance, Uint128::from(2_793_670_659u128));
 
     // 5000 - 3.49 - 2.79
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(4_993_712_676_564u128));
 }
 

--- a/contracts/margined_engine/src/testing/margin_engine_tests.rs
+++ b/contracts/margined_engine/src/testing/margin_engine_tests.rs
@@ -11,7 +11,7 @@ fn test_margin_engine_should_have_enough_balance_after_close_position() {
         mut router,
         alice,
         bob,
-        insurance,
+        insurance_fund,
         engine,
         usdc,
         vamm,
@@ -86,7 +86,9 @@ fn test_margin_engine_should_have_enough_balance_after_close_position() {
         .unwrap();
     router.execute(bob.clone(), msg).unwrap();
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, to_decimals(5_000u64));
 
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
@@ -99,7 +101,7 @@ fn test_margin_engine_does_not_have_enough_balance_after_close_position() {
         mut router,
         alice,
         bob,
-        insurance,
+        insurance_fund,
         engine,
         usdc,
         vamm,
@@ -174,7 +176,9 @@ fn test_margin_engine_does_not_have_enough_balance_after_close_position() {
         .unwrap();
     router.execute(bob.clone(), msg).unwrap();
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(4998_048_780_494u128));
 
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();

--- a/contracts/margined_engine/src/testing/pay_funding_tests.rs
+++ b/contracts/margined_engine/src/testing/pay_funding_tests.rs
@@ -13,7 +13,7 @@ fn test_generate_loss_for_amm_when_funding_rate_is_positive_and_amm_is_long() {
         alice,
         bob,
         owner,
-        insurance,
+        insurance_fund,
         engine,
         vamm,
         usdc,
@@ -100,7 +100,7 @@ fn test_generate_loss_for_amm_when_funding_rate_is_positive_and_amm_is_long() {
     // insuranceFund: 5000 - 1.5
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
     assert_eq!(engine_balance, Uint128::from(1_501_500_000_000u128));
-    let insurance_balance = usdc.balance(&router, insurance).unwrap();
+    let insurance_balance = usdc.balance(&router, insurance_fund.addr()).unwrap();
     assert_eq!(insurance_balance, Uint128::from(4_998_500_000_000u128));
 }
 
@@ -111,7 +111,7 @@ fn test_will_keep_generating_same_loss_when_funding_rate_is_positive() {
         alice,
         bob,
         owner,
-        insurance,
+        insurance_fund,
         engine,
         vamm,
         usdc,
@@ -180,7 +180,7 @@ fn test_will_keep_generating_same_loss_when_funding_rate_is_positive() {
     // insuranceFund: 5000 - 3
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
     assert_eq!(engine_balance, Uint128::from(1_503_000_000_000u128));
-    let insurance_balance = usdc.balance(&router, insurance).unwrap();
+    let insurance_balance = usdc.balance(&router, insurance_fund.addr()).unwrap();
     assert_eq!(insurance_balance, Uint128::from(4_997_000_000_000u128));
 }
 
@@ -691,7 +691,7 @@ fn test_will_change_nothing_if_funding_rate_is_zero() {
         alice,
         bob,
         owner,
-        insurance,
+        insurance_fund,
         engine,
         vamm,
         pricefeed,
@@ -774,6 +774,6 @@ fn test_will_change_nothing_if_funding_rate_is_zero() {
     // insuranceFund: 5000
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
     assert_eq!(engine_balance, Uint128::from(1_500_000_000_000u128));
-    let insurance_balance = usdc.balance(&router, insurance).unwrap();
+    let insurance_balance = usdc.balance(&router, insurance_fund.addr()).unwrap();
     assert_eq!(insurance_balance, Uint128::from(5_000_000_000_000u128));
 }

--- a/contracts/margined_engine/src/testing/position_tests.rs
+++ b/contracts/margined_engine/src/testing/position_tests.rs
@@ -657,7 +657,7 @@ fn test_close_under_collateral_position() {
         mut router,
         alice,
         bob,
-        insurance,
+        insurance_fund,
         engine,
         vamm,
         usdc,
@@ -714,7 +714,9 @@ fn test_close_under_collateral_position() {
     let alice_balance = usdc.balance(&router, alice.clone()).unwrap();
     assert_eq!(alice_balance, Uint128::from(4_975_000_000_000u128));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(4_941_666_666_666u128));
 
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
@@ -747,7 +749,7 @@ fn test_openclose_position_to_check_fee_is_charged() {
         mut router,
         alice,
         owner,
-        insurance,
+        insurance_fund,
         fee_pool,
         engine,
         vamm,
@@ -793,7 +795,9 @@ fn test_openclose_position_to_check_fee_is_charged() {
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
     assert_eq!(engine_balance, to_decimals(0u64));
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, to_decimals(5024u64));
 
     let fee_pool_balance = usdc.balance(&router, fee_pool.clone()).unwrap();
@@ -962,7 +966,7 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_c
         mut router,
         alice,
         bob,
-        insurance,
+        insurance_fund,
         engine,
         usdc,
         vamm,
@@ -1031,7 +1035,7 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_c
     let alice_balance = usdc.balance(&router, alice.clone()).unwrap();
     assert_eq!(alice_balance, Uint128::from(5_094_117_647_059u128));
 
-    // bob close her under collateral position, positionValue is -294.11
+    // bob close his under collateral position, positionValue is -294.11
     // bob's pnl = 200 - 294.11 ~= -94.12
     // bob loss all his margin (20) with additional 74.12 badDebt
     // which is already prepaid by insurance fund when alice close the position before
@@ -1047,6 +1051,8 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_c
     let engine_balance = usdc.balance(&router, engine.addr().clone()).unwrap();
     assert_eq!(engine_balance, Uint128::zero());
 
-    let insurance_balance = usdc.balance(&router, insurance.clone()).unwrap();
+    let insurance_balance = usdc
+        .balance(&router, insurance_fund.addr().clone())
+        .unwrap();
     assert_eq!(insurance_balance, Uint128::from(4_925_882_352_941u128));
 }

--- a/contracts/margined_engine/src/utils.rs
+++ b/contracts/margined_engine/src/utils.rs
@@ -4,15 +4,12 @@ use cosmwasm_std::{
 use terraswap::asset::{Asset, AssetInfo};
 
 use crate::{
-    messages::execute_transfer_from,
+    messages::execute_insurance_fund_withdrawal,
     querier::{
         query_vamm_calc_fee, query_vamm_config, query_vamm_output_price, query_vamm_output_twap,
     },
     query::query_cumulative_premium_fraction,
-    state::{
-        read_config, read_position, read_state, read_vamm, read_vamm_map, store_state, Position,
-        State, VammList,
-    },
+    state::{read_config, read_position, read_vamm, read_vamm_map, Position, State, VammList},
 };
 
 use margined_common::integer::Integer;
@@ -46,31 +43,18 @@ pub fn get_position(
 }
 
 pub fn realize_bad_debt(
-    storage: &mut dyn Storage,
-    contract_address: Addr,
+    deps: Deps,
     bad_debt: Uint128,
     messages: &mut Vec<SubMsg>,
+    state: &mut State,
 ) -> StdResult<Response> {
-    let config = read_config(storage)?;
-    let mut state = read_state(storage)?;
-
     if state.bad_debt.is_zero() {
         // create transfer from message
-        messages.push(
-            execute_transfer_from(
-                storage,
-                &config.insurance_fund,
-                &contract_address,
-                bad_debt, // Uint128::from(1000000000u64),
-            )
-            .unwrap(),
-        );
+        messages.push(execute_insurance_fund_withdrawal(deps, bad_debt).unwrap());
         state.bad_debt = bad_debt;
     } else {
         state.bad_debt = Uint128::zero();
     };
-
-    store_state(storage, &state)?;
 
     Ok(Response::new())
 }

--- a/contracts/margined_insurance_fund/Cargo.toml
+++ b/contracts/margined_insurance_fund/Cargo.toml
@@ -44,9 +44,11 @@ cosmwasm-std = { version = "0.16.3" }
 cosmwasm-storage = { version = "0.16.3" }
 cosmwasm-bignumber = "2.2.0"
 cw-storage-plus = "0.8.0"
+cw20 = { version = "0.9.1" } 
 margined_perp = { version = "0.1.0", path = "../../packages/margined_perp" }
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+terraswap = "2.4.0"
 thiserror = { version = "1.0" }
 
 [dev-dependencies]

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -5,8 +5,9 @@ use crate::{
     state::{store_config, Config},
 };
 #[cfg(not(feature = "library"))]
-use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{
+    entry_point, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+};
 use margined_perp::margined_insurance_fund::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -14,12 +15,11 @@ pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    msg: InstantiateMsg,
+    _msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    let beneficiary = deps.api.addr_validate(&msg.beneficiary)?;
     let config = Config {
         owner: info.sender,
-        beneficiary,
+        beneficiary: Addr::unchecked(""),
     };
 
     store_config(deps.storage, &config)?;
@@ -35,7 +35,9 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::UpdateConfig { owner } => update_config(deps, info, owner),
+        ExecuteMsg::UpdateConfig { owner, beneficiary } => {
+            update_config(deps, info, owner, beneficiary)
+        }
         ExecuteMsg::AddVamm { vamm } => add_vamm(deps, info, vamm),
         ExecuteMsg::RemoveVamm { vamm } => remove_vamm(deps, info, vamm),
         ExecuteMsg::Withdraw { token, amount } => withdraw(deps, info, token, amount),

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::error::ContractError;
 use crate::{
-    handle::{add_vamm, remove_vamm, update_config},
+    handle::{add_vamm, remove_vamm, update_config, withdraw},
     query::{query_config, query_is_vamm},
     state::{store_config, Config},
 };
@@ -14,9 +14,13 @@ pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    _msg: InstantiateMsg,
+    msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    let config = Config { owner: info.sender };
+    let beneficiary = deps.api.addr_validate(&msg.beneficiary)?;
+    let config = Config {
+        owner: info.sender,
+        beneficiary,
+    };
 
     store_config(deps.storage, &config)?;
 
@@ -34,6 +38,7 @@ pub fn execute(
         ExecuteMsg::UpdateConfig { owner } => update_config(deps, info, owner),
         ExecuteMsg::AddVamm { vamm } => add_vamm(deps, info, vamm),
         ExecuteMsg::RemoveVamm { vamm } => remove_vamm(deps, info, vamm),
+        ExecuteMsg::Withdraw { token, amount } => withdraw(deps, info, token, amount),
     }
 }
 

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -14,6 +14,7 @@ pub fn update_config(
     deps: DepsMut,
     info: MessageInfo,
     owner: Option<String>,
+    beneficiary: Option<String>,
 ) -> Result<Response, ContractError> {
     let mut config: Config = read_config(deps.storage)?;
 
@@ -25,6 +26,11 @@ pub fn update_config(
     // change owner of insurance fund contract
     if let Some(owner) = owner {
         config.owner = deps.api.addr_validate(owner.as_str())?;
+    }
+
+    // change owner of insurance fund contract
+    if let Some(beneficiary) = beneficiary {
+        config.beneficiary = deps.api.addr_validate(beneficiary.as_str())?;
     }
 
     store_config(deps.storage, &config)?;

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -1,4 +1,9 @@
-use cosmwasm_std::{DepsMut, MessageInfo, Response};
+use cosmwasm_std::{
+    to_binary, BankMsg, Coin, CosmosMsg, DepsMut, MessageInfo, ReplyOn, Response, SubMsg, Uint128,
+    WasmMsg,
+};
+use cw20::Cw20ExecuteMsg;
+use terraswap::asset::AssetInfo;
 
 use crate::{
     error::ContractError,
@@ -63,4 +68,50 @@ pub fn remove_vamm(
     remove_amm(deps, vamm_valid)?;
 
     Ok(Response::default())
+}
+
+pub fn withdraw(
+    deps: DepsMut,
+    info: MessageInfo,
+    token: AssetInfo,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    let config: Config = read_config(deps.storage)?;
+
+    // check permission
+    if info.sender != config.beneficiary {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // TODO: check that the asset is accepted
+
+    // send tokens if native or cw20
+    let msg: CosmosMsg = match token {
+        AssetInfo::NativeToken { denom } => CosmosMsg::Bank(BankMsg::Send {
+            to_address: config.beneficiary.to_string(),
+            amount: vec![Coin { denom, amount }],
+        }),
+        AssetInfo::Token { contract_addr } => CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr,
+            funds: vec![],
+            msg: to_binary(&Cw20ExecuteMsg::Transfer {
+                recipient: config.beneficiary.to_string(),
+                amount,
+            })?,
+        }),
+    };
+
+    let transfer_msg = SubMsg {
+        msg,
+        gas_limit: None, // probably should set a limit in the config
+        id: 0u64,
+        reply_on: ReplyOn::Never,
+    };
+
+    Ok(Response::default()
+        .add_submessage(transfer_msg)
+        .add_attributes(vec![
+            ("action", "insurance_withdraw"),
+            ("amount", &amount.to_string()),
+        ]))
 }

--- a/contracts/margined_insurance_fund/src/query.rs
+++ b/contracts/margined_insurance_fund/src/query.rs
@@ -9,6 +9,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 
     Ok(ConfigResponse {
         owner: config.owner,
+        beneficiary: config.beneficiary,
     })
 }
 

--- a/contracts/margined_insurance_fund/src/state.rs
+++ b/contracts/margined_insurance_fund/src/state.rs
@@ -39,9 +39,11 @@ pub fn remove_amm(deps: DepsMut, input: Addr) -> StdResult<()> {
     VAMM_LIST.remove(deps.storage, input);
     Ok(())
 }
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: Addr,
+    pub beneficiary: Addr,
 }
 
 pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -5,23 +5,35 @@ use margined_perp::margined_insurance_fund::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VammResponse,
 };
 
+const BENEFICIARY: &str = "beneficiary";
+
 #[test]
 fn test_instantiation() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
     let config: ConfigResponse = from_binary(&res).unwrap();
     let info = mock_info("addr0000", &[]);
-    assert_eq!(config, ConfigResponse { owner: info.sender });
+    assert_eq!(
+        config,
+        ConfigResponse {
+            beneficiary: Addr::unchecked(BENEFICIARY.to_string()),
+            owner: info.sender
+        }
+    );
 }
 
 #[test]
 fn test_update_config() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -38,6 +50,8 @@ fn test_update_config() {
     assert_eq!(
         config,
         ConfigResponse {
+            beneficiary: Addr::unchecked(BENEFICIARY.to_string()),
+
             owner: Addr::unchecked("addr0001".to_string()),
         }
     );
@@ -46,7 +60,9 @@ fn test_update_config() {
 fn test_query_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -92,7 +108,9 @@ fn test_query_all_vamm() {
 fn test_add_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -142,7 +160,9 @@ fn test_add_second_vamm() {
 
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -183,7 +203,9 @@ fn test_add_second_vamm() {
 fn test_remove_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -239,7 +261,9 @@ fn test_remove_vamm() {
 fn test_not_owner() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -10,9 +10,7 @@ const BENEFICIARY: &str = "beneficiary";
 #[test]
 fn test_instantiation() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -22,7 +20,7 @@ fn test_instantiation() {
     assert_eq!(
         config,
         ConfigResponse {
-            beneficiary: Addr::unchecked(BENEFICIARY.to_string()),
+            beneficiary: Addr::unchecked("".to_string()),
             owner: info.sender
         }
     );
@@ -31,15 +29,14 @@ fn test_instantiation() {
 #[test]
 fn test_update_config() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // Update the config
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("addr0001".to_string()),
+        beneficiary: Some(BENEFICIARY.to_string()),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -60,9 +57,7 @@ fn test_update_config() {
 fn test_query_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -108,9 +103,7 @@ fn test_query_all_vamm() {
 fn test_add_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -160,9 +153,7 @@ fn test_add_second_vamm() {
 
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -203,9 +194,7 @@ fn test_add_second_vamm() {
 fn test_remove_vamm() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -261,9 +250,7 @@ fn test_remove_vamm() {
 fn test_not_owner() {
     //instantiate contract here
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        beneficiary: BENEFICIARY.to_string(),
-    };
+    let msg = InstantiateMsg {};
     let info = mock_info("addr0000", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -271,6 +258,7 @@ fn test_not_owner() {
     // try to update the config
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("addr0001".to_string()),
+        beneficiary: None,
     };
 
     let info = mock_info("not_the_owner", &[]);

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -4,17 +4,25 @@ use terraswap::asset::AssetInfo;
 
 use cosmwasm_std::{Addr, Uint128};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-    pub beneficiary: String,
-}
+pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    UpdateConfig { owner: Option<String> },
-    AddVamm { vamm: String },
-    RemoveVamm { vamm: String },
-    Withdraw { token: AssetInfo, amount: Uint128 },
+    UpdateConfig {
+        owner: Option<String>,
+        beneficiary: Option<String>,
+    },
+    AddVamm {
+        vamm: String,
+    },
+    RemoveVamm {
+        vamm: String,
+    },
+    Withdraw {
+        token: AssetInfo,
+        amount: Uint128,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -1,9 +1,12 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use terraswap::asset::AssetInfo;
 
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Uint128};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {}
+pub struct InstantiateMsg {
+    pub beneficiary: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -11,6 +14,7 @@ pub enum ExecuteMsg {
     UpdateConfig { owner: Option<String> },
     AddVamm { vamm: String },
     RemoveVamm { vamm: String },
+    Withdraw { token: AssetInfo, amount: Uint128 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -23,6 +27,7 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
     pub owner: Addr,
+    pub beneficiary: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/margined_utils/Cargo.toml
+++ b/packages/margined_utils/Cargo.toml
@@ -23,6 +23,7 @@ margined_common = { version = "0.1.0", path = "../margined_common"}
 margined_perp = { version = "0.1.0", path = "../margined_perp"}
 margined_vamm = { version = "0.1.0", path = "../../contracts/margined_vamm" }
 margined_engine = { version = "0.1.0", path = "../../contracts/margined_engine" }
+margined_insurance_fund = { version = "0.1.0", path = "../../contracts/margined_insurance_fund" }
 margined_pricefeed = { version = "0.1.0", path = "../../contracts/margined_pricefeed" }
 mock_pricefeed = { version = "0.1.0", path = "../../contracts/mocks/mock_pricefeed" }
 terraswap = { version = "2.4.0" }

--- a/packages/margined_utils/src/contracts/helpers.rs
+++ b/packages/margined_utils/src/contracts/helpers.rs
@@ -3,5 +3,6 @@ pub use crate::contracts::helpers::margined_pricefeed::PricefeedController;
 pub use crate::contracts::helpers::margined_vamm::VammController;
 
 pub mod margined_engine;
+pub mod margined_insurance_fund;
 pub mod margined_pricefeed;
 pub mod margined_vamm;

--- a/packages/margined_utils/src/contracts/helpers/margined_insurance_fund.rs
+++ b/packages/margined_utils/src/contracts/helpers/margined_insurance_fund.rs
@@ -1,0 +1,51 @@
+use margined_perp::margined_insurance_fund::{ConfigResponse, ExecuteMsg, QueryMsg};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{
+    to_binary, Addr, Coin, CosmosMsg, Querier, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
+};
+
+/// InsuranceFundController is a wrapper around Addr that provides a lot of helpers
+/// for working with this.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InsuranceFundController(pub Addr);
+
+impl InsuranceFundController {
+    pub fn addr(&self) -> Addr {
+        self.0.clone()
+    }
+
+    pub fn call<T: Into<ExecuteMsg>>(&self, msg: T, funds: Vec<Coin>) -> StdResult<CosmosMsg> {
+        let msg = to_binary(&msg.into())?;
+        Ok(WasmMsg::Execute {
+            contract_addr: self.addr().into(),
+            msg,
+            funds,
+        }
+        .into())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_config(
+        &self,
+        owner: Option<String>,
+        beneficiary: Option<String>,
+    ) -> StdResult<CosmosMsg> {
+        let msg = ExecuteMsg::UpdateConfig { owner, beneficiary };
+        self.call(msg, vec![])
+    }
+
+    /// get margin insurance fund configuration
+    pub fn config<Q: Querier>(&self, querier: &Q) -> StdResult<ConfigResponse> {
+        let msg = QueryMsg::Config {};
+        let query = WasmQuery::Smart {
+            contract_addr: self.addr().into(),
+            msg: to_binary(&msg)?,
+        }
+        .into();
+
+        let res: ConfigResponse = QuerierWrapper::new(querier).query(&query)?;
+        Ok(res)
+    }
+}


### PR DESCRIPTION
In this PR the feature **withdraw** is added to the insurance fund contract.

This enables the address set as a beneficiary to withdraw funds held by the contract.

This feature is required to enable the insurance fund to hold native tokens for the margin engine and be used in a shortfall situation.