### PR TITLE
Todo/cleanup

### DIFF
--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -160,8 +160,8 @@ pub fn open_position(
     let position: Position = get_position(env.clone(), deps.storage, &vamm, &trader, side.clone());
 
     // note: if direction and side are same way then increasing else we are reversing
-    let is_increase: bool = position.direction == Direction::AddToAmm && side == Side::BUY
-        || position.direction == Direction::RemoveFromAmm && side == Side::SELL;
+    let is_increase: bool = position.direction == Direction::AddToAmm && side == Side::Buy
+        || position.direction == Direction::RemoveFromAmm && side == Side::Sell;
 
     // calculate the position size
     let open_notional = quote_asset_amount
@@ -578,9 +578,9 @@ fn partial_liquidation(
         .unwrap();
 
     let side = if position.size > Integer::zero() {
-        Side::SELL
+        Side::Sell
     } else {
-        Side::BUY
+        Side::Buy
     };
 
     store_tmp_swap(

--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -189,7 +189,7 @@ pub fn open_position(
     let PositionUnrealizedPnlResponse {
         position_notional,
         unrealized_pnl,
-    } = get_position_notional_unrealized_pnl(deps.as_ref(), &position, PnlCalcOption::SPOTPRICE)
+    } = get_position_notional_unrealized_pnl(deps.as_ref(), &position, PnlCalcOption::SpotPrice)
         .unwrap();
 
     store_tmp_swap(
@@ -502,7 +502,7 @@ fn open_reverse_position(
     let PositionUnrealizedPnlResponse {
         position_notional,
         unrealized_pnl: _,
-    } = get_position_notional_unrealized_pnl(deps.as_ref(), &position, PnlCalcOption::SPOTPRICE)
+    } = get_position_notional_unrealized_pnl(deps.as_ref(), &position, PnlCalcOption::SpotPrice)
         .unwrap();
 
     // reduce position if old position is larger
@@ -574,7 +574,7 @@ fn partial_liquidation(
     let PositionUnrealizedPnlResponse {
         position_notional: _,
         unrealized_pnl,
-    } = get_position_notional_unrealized_pnl(deps.as_ref(), &position, PnlCalcOption::SPOTPRICE)
+    } = get_position_notional_unrealized_pnl(deps.as_ref(), &position, PnlCalcOption::SpotPrice)
         .unwrap();
 
     let side = if position.size > Integer::zero() {

--- a/contracts/margined_engine/src/query.rs
+++ b/contracts/margined_engine/src/query.rs
@@ -163,11 +163,11 @@ pub fn query_margin_ratio(deps: Deps, vamm: String, trader: String) -> StdResult
     let PositionUnrealizedPnlResponse {
         position_notional: spot_notional,
         unrealized_pnl: spot_pnl,
-    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::SPOTPRICE)?;
+    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::SpotPrice)?;
     let PositionUnrealizedPnlResponse {
         position_notional: twap_notional,
         unrealized_pnl: twap_pnl,
-    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::TWAP)?;
+    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::Twap)?;
 
     // calculate and return margin
     let PositionUnrealizedPnlResponse {
@@ -206,11 +206,11 @@ pub fn query_free_collateral(deps: Deps, vamm: String, trader: String) -> StdRes
     let PositionUnrealizedPnlResponse {
         position_notional: spot_notional,
         unrealized_pnl: spot_pnl,
-    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::SPOTPRICE)?;
+    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::SpotPrice)?;
     let PositionUnrealizedPnlResponse {
         position_notional: twap_notional,
         unrealized_pnl: twap_pnl,
-    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::TWAP)?;
+    } = get_position_notional_unrealized_pnl(deps, &position, PnlCalcOption::Twap)?;
 
     // calculate and return margin
     let PositionUnrealizedPnlResponse {

--- a/contracts/margined_engine/src/testing/cw_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_add_remove_margin_tests.rs
@@ -20,7 +20,7 @@ fn test_add_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -82,7 +82,7 @@ fn test_remove_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -135,7 +135,7 @@ fn test_remove_margin_after_paying_funding() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -199,7 +199,7 @@ fn test_remove_margin_insufficient_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -232,7 +232,7 @@ fn test_remove_margin_incorrect_ratio_four_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -266,7 +266,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_spot_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -279,7 +279,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_spot_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -321,7 +321,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_spot_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -334,7 +334,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_spot_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(10u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -375,7 +375,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_spot_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -388,7 +388,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_spot_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -437,7 +437,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_spot_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -449,7 +449,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_spot_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(10u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -491,7 +491,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_twap_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -509,7 +509,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_twap_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -556,7 +556,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_twap_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -574,7 +574,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_twap_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(10u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -620,7 +620,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_twap_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -638,7 +638,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_twap_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -692,7 +692,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_twap_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -709,7 +709,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_twap_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(10u64),
             to_decimals(5u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/cw_token_liquidation_frontrun_hack_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_liquidation_frontrun_hack_tests.rs
@@ -102,7 +102,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(9_090_000_000u128),
@@ -120,7 +120,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::zero(),
@@ -139,7 +139,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::zero(),
@@ -158,7 +158,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -286,7 +286,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(9_090_000_000u128),
@@ -304,7 +304,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(7_570_000_000u128),
@@ -322,7 +322,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(7_580_000_000u128),
@@ -340,7 +340,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -473,7 +473,7 @@ fn test_can_open_position_long_and_liquidate_but_cannot_do_anything_more_in_same
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::zero(),
@@ -491,7 +491,7 @@ fn test_can_open_position_long_and_liquidate_but_cannot_do_anything_more_in_same
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::zero(),
@@ -520,7 +520,7 @@ fn test_can_open_position_long_and_liquidate_but_cannot_do_anything_more_in_same
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -653,7 +653,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(9_090_000_000u128),
@@ -671,7 +671,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(7_570_000_000u128),
@@ -689,7 +689,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(7_580_000_000u128),
@@ -707,7 +707,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(10u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -840,7 +840,7 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::zero(),
@@ -858,7 +858,7 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::zero(),
@@ -887,7 +887,7 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(10u64),
             to_decimals(1u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/cw_token_liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_liquidation_tests.rs
@@ -1054,7 +1054,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -1067,7 +1067,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::TWAP,
+            PnlCalcOption::Twap,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(9_386_059_960u128));
@@ -1194,7 +1194,7 @@ fn test_force_error_position_not_liquidation_spot_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(10u128));
@@ -1204,7 +1204,7 @@ fn test_force_error_position_not_liquidation_spot_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::TWAP,
+            PnlCalcOption::Twap,
         )
         .unwrap();
     assert_eq!(

--- a/contracts/margined_engine/src/testing/cw_token_liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_liquidation_tests.rs
@@ -84,7 +84,7 @@ fn test_partially_liquidate_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -103,7 +103,7 @@ fn test_partially_liquidate_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(45_180_722_890u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -218,7 +218,7 @@ fn test_partially_liquidate_long_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -237,7 +237,7 @@ fn test_partially_liquidate_long_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(45_180_722_890u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -348,7 +348,7 @@ fn test_partially_liquidate_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -367,7 +367,7 @@ fn test_partially_liquidate_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(19_672_131_150u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -482,7 +482,7 @@ fn test_partially_liquidate_short_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -501,7 +501,7 @@ fn test_partially_liquidate_short_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(19_672_131_150u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -612,7 +612,7 @@ fn test_long_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -631,7 +631,7 @@ fn test_long_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(73_529_411_760u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -737,7 +737,7 @@ fn test_long_position_complete_liquidation_with_slippage_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -756,7 +756,7 @@ fn test_long_position_complete_liquidation_with_slippage_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(73_529_411_760u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -863,7 +863,7 @@ fn test_short_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -882,7 +882,7 @@ fn test_short_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(40_336_134_450u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -988,7 +988,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -1007,7 +1007,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -1026,7 +1026,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -1165,7 +1165,7 @@ fn test_force_error_position_not_liquidation_spot_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -1331,7 +1331,7 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1342,7 +1342,7 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     // alice get: 90.9090909091 - 83.3333333333 = 7.5757575758
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1351,7 +1351,7 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1490,7 +1490,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // actual margin ratio is 19.99...9%
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1500,7 +1500,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // AMM after: quote = 1150
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1510,7 +1510,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // AMM after: quote = 1200
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1520,7 +1520,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1666,7 +1666,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // actual margin ratio is 19.99...9%
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1676,7 +1676,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // AMM after: quote = 1150
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1686,7 +1686,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // AMM after: quote = 1200
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1697,7 +1697,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // alice + carol + david get: 90.9090909091 - 82.6446281 = 8.2644628091
     env.open_small_position(
         env.david.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(400_000_000u128), // 0.4
         to_decimals(5u64),
         5u64,
@@ -1706,7 +1706,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // AMM after: 1110 : 90.09009009, price: 12.321
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1861,7 +1861,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -1871,7 +1871,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: quote = 1150 : 86.9565217391
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1881,7 +1881,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: quote = 1200
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1892,7 +1892,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // alice + carol + david get: 90.9090909091 - 80 = 10.9090909091
     env.open_small_position(
         env.david.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(2u64),
         to_decimals(5u64),
         5u64,
@@ -1901,7 +1901,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: 1150 : 86.9565217391, price: 13.225
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2030,7 +2030,7 @@ fn test_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2041,7 +2041,7 @@ fn test_liquidate_one_position_exceeding_fluctuation_limit() {
     // alice get: 90.9090909091 - 83.3333333333 = 7.5757575758
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2050,7 +2050,7 @@ fn test_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2158,7 +2158,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2169,7 +2169,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
     // alice get: 90.9090909091 - 83.3333333333 = 7.5757575758
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2178,7 +2178,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(4u64),
         to_decimals(5u64),
         5u64,
@@ -2200,7 +2200,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(44u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -2349,7 +2349,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(10u64),
         to_decimals(5u64),
         2u64,
@@ -2359,7 +2359,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1150 : 86.9565217391
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(5u64),
         to_decimals(5u64),
         2u64,
@@ -2370,7 +2370,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1200 : 83.3333333, price: 14.4
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         to_decimals(5u64),
         to_decimals(5u64),
         2u64,
@@ -2379,7 +2379,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         to_decimals(10u64),
         to_decimals(5u64),
         2u64,

--- a/contracts/margined_engine/src/testing/cw_token_pay_funding_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_pay_funding_tests.rs
@@ -24,7 +24,7 @@ fn test_generate_loss_for_amm_when_funding_rate_is_positive_and_amm_is_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -36,7 +36,7 @@ fn test_generate_loss_for_amm_when_funding_rate_is_positive_and_amm_is_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -122,7 +122,7 @@ fn test_will_keep_generating_same_loss_when_funding_rate_is_positive() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -134,7 +134,7 @@ fn test_will_keep_generating_same_loss_when_funding_rate_is_positive() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -200,7 +200,7 @@ fn test_funding_rate_is_1_percent_then_negative_1_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -212,7 +212,7 @@ fn test_funding_rate_is_1_percent_then_negative_1_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -318,7 +318,7 @@ fn test_have_huge_funding_payment_profit_withdraw_excess_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -330,7 +330,7 @@ fn test_have_huge_funding_payment_profit_withdraw_excess_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -397,7 +397,7 @@ fn test_have_huge_funding_payment_margin_zero_with_bad_debt() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -409,7 +409,7 @@ fn test_have_huge_funding_payment_margin_zero_with_bad_debt() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -473,7 +473,7 @@ fn test_have_huge_funding_payment_margin_zero_can_add_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -485,7 +485,7 @@ fn test_have_huge_funding_payment_margin_zero_can_add_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -548,7 +548,7 @@ fn test_have_huge_funding_payment_margin_zero_cannot_remove_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -560,7 +560,7 @@ fn test_have_huge_funding_payment_margin_zero_cannot_remove_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -619,7 +619,7 @@ fn test_reduce_bad_debt_after_adding_margin_to_an_underwater_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -631,7 +631,7 @@ fn test_reduce_bad_debt_after_adding_margin_to_an_underwater_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -702,7 +702,7 @@ fn test_will_change_nothing_if_funding_rate_is_zero() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -714,7 +714,7 @@ fn test_will_change_nothing_if_funding_rate_is_zero() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(1200u64),
             to_decimals(1u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/cw_token_position_fee_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_position_fee_tests.rs
@@ -30,7 +30,7 @@ fn test_ten_percent_fee_open_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -82,7 +82,7 @@ fn test_ten_percent_fee_open_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(150_000_000_000u64),
@@ -134,7 +134,7 @@ fn test_ten_percent_fee_increase_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -151,7 +151,7 @@ fn test_ten_percent_fee_increase_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(175_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(17_500_000_000u64),
@@ -207,7 +207,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -224,7 +224,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(35_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(17_500_000_000u64),
@@ -251,7 +251,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(200_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(12_500_000_000u64),
@@ -306,7 +306,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(125_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -322,7 +322,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(125_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -349,7 +349,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000_000u64),
             Uint128::from(5_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -398,7 +398,7 @@ fn test_ten_percent_fee_increase_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -414,7 +414,7 @@ fn test_ten_percent_fee_increase_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(50_000_000_000u64),
             Uint128::from(8_000_000_000u64),
             Uint128::from(125_000_000_000u64),
@@ -474,7 +474,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -490,7 +490,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(150_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(75_000_000_000u64),
@@ -520,7 +520,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(3_000_000_000u64),
             Uint128::from(300_000_000_000u64),
@@ -570,7 +570,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(200_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -586,7 +586,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(200_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -616,7 +616,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(50_000_000_000u64),
             Uint128::from(4_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -662,7 +662,7 @@ fn test_ten_percent_fee_reduce_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -674,7 +674,7 @@ fn test_ten_percent_fee_reduce_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(350_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(17_500_000_000u64),
@@ -721,7 +721,7 @@ fn test_ten_percent_fee_reduce_long_position_zero_fee() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -733,7 +733,7 @@ fn test_ten_percent_fee_reduce_long_position_zero_fee() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(350_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(17_500_000_000u64),
@@ -781,7 +781,7 @@ fn test_ten_percent_fee_reduce_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(150_000_000_000u64),
@@ -793,7 +793,7 @@ fn test_ten_percent_fee_reduce_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(400_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(125_000_000_000u64),
@@ -842,7 +842,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -854,7 +854,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(400_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(12_500_000_000u64),
@@ -879,7 +879,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(400_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(12_500_000_000u64),
@@ -931,7 +931,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(500_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(50_000_000_000u64),
@@ -943,7 +943,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(400_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(12_500_000_000u64),
@@ -968,7 +968,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(350_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(17_500_000_000u64),
@@ -1020,7 +1020,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -1032,7 +1032,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(7_350_000_000u64),
@@ -1054,7 +1054,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(150_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(17_640_000_000u64),
@@ -1103,7 +1103,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(250_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(100_000_000_000u64),
@@ -1115,7 +1115,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(50_000_000_000u64),
@@ -1140,7 +1140,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(100_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(50_000_000_000u64),
@@ -1192,7 +1192,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000_000u64),
             Uint128::from(5_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -1206,7 +1206,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(250_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -1251,7 +1251,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -1265,7 +1265,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(200_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -1310,7 +1310,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(125_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -1324,7 +1324,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(45_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(45_000_000_000u64),
@@ -1369,7 +1369,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -1383,7 +1383,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(90_000_000_000u64),
             Uint128::from(5_000_000_000u64),
             Uint128::from(45_000_000_000u64),
@@ -1440,7 +1440,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -1454,7 +1454,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(35_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(17_500_000_000u64),
@@ -1479,7 +1479,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(8_000_000_000u64),
             Uint128::from(62_510_000_000u64),
@@ -1538,7 +1538,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(125_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -1552,7 +1552,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(125_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(20_000_000_000u64),
@@ -1574,7 +1574,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(1_450_000_000_000u64),
@@ -1629,7 +1629,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(200_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(25_000_000_000u64),
@@ -1641,7 +1641,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000_000u64),
             Uint128::from(4_000_000_000u64),
             Uint128::from(7_349_000_000u64),
@@ -1666,7 +1666,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(37_490_000_000u64),
@@ -1716,7 +1716,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(500_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(100_000_000_000u64),
@@ -1730,7 +1730,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000_000u64),
             Uint128::from(1_000_000_000u64),
             Uint128::from(50_000_000_000u64),
@@ -1755,7 +1755,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::from(149_990_000_000u64),

--- a/contracts/margined_engine/src/testing/cw_token_position_fee_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_position_fee_tests.rs
@@ -238,7 +238,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -339,7 +339,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(83_333_333_334u64));
@@ -443,7 +443,7 @@ fn test_ten_percent_fee_increase_short_position() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -507,7 +507,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -603,7 +603,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -695,7 +695,7 @@ fn test_ten_percent_fee_reduce_long_position() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -754,7 +754,7 @@ fn test_ten_percent_fee_reduce_long_position_zero_fee() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -814,7 +814,7 @@ fn test_ten_percent_fee_reduce_short_position() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -868,7 +868,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -900,7 +900,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -957,7 +957,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -989,7 +989,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -1046,7 +1046,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(29_365_079_364u64));
@@ -1075,7 +1075,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(8_636_788_056u64));
@@ -1129,7 +1129,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -1161,7 +1161,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -1410,7 +1410,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -1468,7 +1468,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -1506,7 +1506,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(9u64));
@@ -1566,7 +1566,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(83_333_333_334u64));
@@ -1601,7 +1601,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(3u64));
@@ -1655,7 +1655,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(
@@ -1687,7 +1687,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(21u64));
@@ -1744,7 +1744,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(

--- a/contracts/margined_engine/src/testing/fee_calculation_tests.rs
+++ b/contracts/margined_engine/src/testing/fee_calculation_tests.rs
@@ -33,7 +33,7 @@ fn test_open_position_total_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -88,7 +88,7 @@ fn test_open_short_position_twice_total_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(50_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(11_200_000_000u64),
@@ -102,7 +102,7 @@ fn test_open_short_position_twice_total_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(50_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(139_000_000_000u64),
@@ -158,7 +158,7 @@ fn test_open_and_close_position_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -210,7 +210,7 @@ fn test_open_position_close_manually_open_reverse_position_total_fee_ten_percent
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::zero(),
@@ -231,7 +231,7 @@ fn test_open_position_close_manually_open_reverse_position_total_fee_ten_percent
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             pnl.position_notional,
             Uint128::from(1_000_000_000u64),
             Uint128::zero(),
@@ -279,7 +279,7 @@ fn test_open_position_close_manually_open_reverse_position_short_then_long_total
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(300_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::zero(),
@@ -300,7 +300,7 @@ fn test_open_position_close_manually_open_reverse_position_short_then_long_total
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             pnl.position_notional,
             Uint128::from(1_000_000_000u64),
             Uint128::zero(),
@@ -362,7 +362,7 @@ fn test_close_under_collateral_position_total_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::zero(),
@@ -374,7 +374,7 @@ fn test_close_under_collateral_position_total_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(10_000_000_000u64),
             Uint128::from(10_000_000_000u64),
             Uint128::zero(),
@@ -430,7 +430,7 @@ fn test_force_error_insufficient_balance_open_position_total_fee_ten_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::from(37_500_000_000u64),
@@ -470,7 +470,7 @@ fn test_has_spread_no_toll() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000_000u64),
             Uint128::from(2_000_000_000u64),
             Uint128::zero(),

--- a/contracts/margined_engine/src/testing/fee_calculation_tests.rs
+++ b/contracts/margined_engine/src/testing/fee_calculation_tests.rs
@@ -224,7 +224,7 @@ fn test_open_position_close_manually_open_reverse_position_total_fee_ten_percent
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
 
@@ -293,7 +293,7 @@ fn test_open_position_close_manually_open_reverse_position_short_then_long_total
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
 
@@ -438,7 +438,6 @@ fn test_force_error_insufficient_balance_open_position_total_fee_ten_percent() {
         )
         .unwrap();
     let response = router.execute(alice.clone(), msg).unwrap_err();
-    // TODO this is correct but maybe we can improve this error message
     assert_eq!(
         response.to_string(),
         "Overflow: Cannot Sub with 29000000000 and 30000000000".to_string()

--- a/contracts/margined_engine/src/testing/fluctuation_tests.rs
+++ b/contracts/margined_engine/src/testing/fluctuation_tests.rs
@@ -41,7 +41,7 @@ fn test_force_error_open_position_exceeds_fluctuation_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -86,7 +86,7 @@ fn test_force_error_reduce_position_exceeds_fluctuation_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -105,7 +105,7 @@ fn test_force_error_reduce_position_exceeds_fluctuation_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(50u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -163,7 +163,7 @@ fn test_close_position_limit_force_error_exceeding_fluctuation_limit_twice_in_sa
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -182,7 +182,7 @@ fn test_close_position_limit_force_error_exceeding_fluctuation_limit_twice_in_sa
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -270,7 +270,7 @@ fn test_close_position_slippage_limit_originally_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -289,7 +289,7 @@ fn test_close_position_slippage_limit_originally_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -366,7 +366,7 @@ fn test_close_position_slippage_limit_originally_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(11_111_111_112u128),
@@ -385,7 +385,7 @@ fn test_close_position_slippage_limit_originally_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(13_890_000_000u128),
@@ -460,7 +460,7 @@ fn test_force_error_close_position_slippage_limit_originally_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(9u64),
@@ -477,7 +477,7 @@ fn test_force_error_close_position_slippage_limit_originally_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(7_500_000_000u128),
@@ -547,7 +547,7 @@ fn test_force_error_close_position_slippage_limit_originally_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(11_111_111_112u128),
@@ -564,7 +564,7 @@ fn test_force_error_close_position_slippage_limit_originally_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(13_890_000_000u128),

--- a/contracts/margined_engine/src/testing/margin_engine_tests.rs
+++ b/contracts/margined_engine/src/testing/margin_engine_tests.rs
@@ -50,7 +50,7 @@ fn test_margin_engine_should_have_enough_balance_after_close_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -63,7 +63,7 @@ fn test_margin_engine_should_have_enough_balance_after_close_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(25u64),
             to_decimals(4u64),
             to_decimals(0u64),
@@ -140,7 +140,7 @@ fn test_margin_engine_does_not_have_enough_balance_after_close_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -153,7 +153,7 @@ fn test_margin_engine_does_not_have_enough_balance_after_close_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/margin_ratio_tests.rs
+++ b/contracts/margined_engine/src/testing/margin_ratio_tests.rs
@@ -16,7 +16,7 @@ fn test_get_margin_ratio() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -46,7 +46,7 @@ fn test_get_margin_ratio_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -63,7 +63,7 @@ fn test_get_margin_ratio_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(15u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -98,7 +98,7 @@ fn test_get_margin_ratio_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -110,7 +110,7 @@ fn test_get_margin_ratio_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(15u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -146,7 +146,7 @@ fn test_get_margin_higher_twap() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -163,7 +163,7 @@ fn test_get_margin_higher_twap() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(15u64),
             to_decimals(10u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
@@ -19,7 +19,7 @@ fn test_add_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -132,7 +132,7 @@ fn test_remove_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -187,7 +187,7 @@ fn test_remove_margin_after_paying_funding() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(0_000_000u64),
@@ -258,7 +258,7 @@ fn test_remove_margin_insufficient_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(0_000_000u64),
@@ -294,7 +294,7 @@ fn test_remove_margin_incorrect_ratio_four_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(0_000_000u64),
@@ -332,7 +332,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_spot_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0_000_000u64),
@@ -345,7 +345,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_spot_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0_000_000u64),
@@ -387,7 +387,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_spot_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -400,7 +400,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_spot_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(10_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -441,7 +441,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_spot_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -454,7 +454,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_spot_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -503,7 +503,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_spot_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -515,7 +515,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_spot_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(10_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -557,7 +557,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_twap_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -575,7 +575,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_profit_using_twap_price(
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -622,7 +622,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_twap_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -640,7 +640,7 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_twap_price() 
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(10_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -686,7 +686,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_twap_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -704,7 +704,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_profit_using_twap_price
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -758,7 +758,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_twap_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),
@@ -775,7 +775,7 @@ fn test_remove_margin_unrealized_pnl_short_position_with_loss_using_twap_price()
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(10_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(0u64),

--- a/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
@@ -419,10 +419,10 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_spot_price() 
     let free_collateral = engine
         .get_free_collateral(&router, vamm.addr().to_string(), alice.to_string())
         .unwrap();
-    assert_eq!(free_collateral, Integer::new_positive(24_850_745u128));
+    assert_eq!(free_collateral, Integer::new_positive(24_850_742u128));
 
     let msg = engine
-        .withdraw_margin(vamm.addr().to_string(), Uint128::from(24_850_745u128))
+        .withdraw_margin(vamm.addr().to_string(), Uint128::from(24_850_742u128))
         .unwrap();
     router.execute(alice.clone(), msg).unwrap();
 }
@@ -664,10 +664,10 @@ fn test_remove_margin_unrealized_pnl_long_position_with_loss_using_twap_price() 
     let free_collateral = engine
         .get_free_collateral(&router, vamm.addr().to_string(), alice.to_string())
         .unwrap();
-    assert_eq!(free_collateral, Integer::new_positive(34_925_372u128));
+    assert_eq!(free_collateral, Integer::new_positive(34_925_370u128));
 
     let msg = engine
-        .withdraw_margin(vamm.addr().to_string(), Uint128::from(34_925_372u128))
+        .withdraw_margin(vamm.addr().to_string(), Uint128::from(34_925_370u128))
         .unwrap();
     router.execute(alice.clone(), msg).unwrap();
 }

--- a/contracts/margined_engine/src/testing/native_token_liquidation_frontrun_hack_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_liquidation_frontrun_hack_tests.rs
@@ -51,7 +51,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(9_090_000u128),
@@ -69,7 +69,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -87,7 +87,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -105,7 +105,7 @@ fn test_liquidator_can_open_position_and_liquidate_in_next_block() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -184,7 +184,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(9_090_000u128),
@@ -202,7 +202,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(7_570_000u128),
@@ -220,7 +220,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(7_580_000u128),
@@ -238,7 +238,7 @@ fn test_can_open_position_short_and_liquidate_but_cannot_do_anything_more_in_sam
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -322,7 +322,7 @@ fn test_can_open_position_long_and_liquidate_but_cannot_do_anything_more_in_same
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -340,7 +340,7 @@ fn test_can_open_position_long_and_liquidate_but_cannot_do_anything_more_in_same
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -369,7 +369,7 @@ fn test_can_open_position_long_and_liquidate_but_cannot_do_anything_more_in_same
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -453,7 +453,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(9_090_000u128),
@@ -471,7 +471,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(7_570_000u128),
@@ -489,7 +489,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(7_580_000u128),
@@ -507,7 +507,7 @@ fn test_can_open_position_and_liquidate_but_cannot_do_anything_more_in_same_bloc
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(10_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(0u64),
@@ -591,7 +591,7 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -609,7 +609,7 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -638,7 +638,7 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(10_000_000u64),
             Uint128::from(1u64),
             Uint128::zero(),

--- a/contracts/margined_engine/src/testing/native_token_liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_liquidation_tests.rs
@@ -821,7 +821,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(15_384_623u128));
@@ -831,7 +831,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::TWAP,
+            PnlCalcOption::Twap,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(9_386_068u128));
@@ -928,7 +928,7 @@ fn test_force_error_position_not_liquidation_spot_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(1u128));
@@ -938,7 +938,7 @@ fn test_force_error_position_not_liquidation_spot_over_maintenance_margin() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::TWAP,
+            PnlCalcOption::Twap,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(16_388_891u128));

--- a/contracts/margined_engine/src/testing/native_token_liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_liquidation_tests.rs
@@ -1086,8 +1086,8 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     env.router.execute(env.carol.clone(), msg).unwrap();
 
     let state = env.vamm.state(&env.router).unwrap();
-    assert_eq!(state.quote_asset_reserve, Uint128::from(1_077_551_027u128));
-    assert_eq!(state.base_asset_reserve, Uint128::from(92_803_035u128));
+    assert_eq!(state.quote_asset_reserve, Uint128::from(1_077_551_039u128));
+    assert_eq!(state.base_asset_reserve, Uint128::from(92_803_036u128));
 }
 
 #[test]
@@ -1511,7 +1511,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     env.router.execute(env.bob.clone(), msg).unwrap();
 
     let state = env.vamm.state(&env.router).unwrap();
-    assert_eq!(state.quote_asset_reserve, Uint128::from(1_084_789_408u128));
+    assert_eq!(state.quote_asset_reserve, Uint128::from(1_084_789_420u128));
     assert_eq!(state.base_asset_reserve, Uint128::from(92_183_802u128));
 }
 

--- a/contracts/margined_engine/src/testing/native_token_liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_liquidation_tests.rs
@@ -54,7 +54,7 @@ fn test_partially_liquidate_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -73,7 +73,7 @@ fn test_partially_liquidate_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(45_180_723u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -157,7 +157,7 @@ fn test_partially_liquidate_long_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -176,7 +176,7 @@ fn test_partially_liquidate_long_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(45_180_723u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -258,7 +258,7 @@ fn test_partially_liquidate_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -277,7 +277,7 @@ fn test_partially_liquidate_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(19_672_131u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -361,7 +361,7 @@ fn test_partially_liquidate_short_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -380,7 +380,7 @@ fn test_partially_liquidate_short_position_with_quote_asset_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(19_672_131u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -462,7 +462,7 @@ fn test_long_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -481,7 +481,7 @@ fn test_long_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(73_529_411u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -560,7 +560,7 @@ fn test_long_position_complete_liquidation_with_slippage_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -579,7 +579,7 @@ fn test_long_position_complete_liquidation_with_slippage_limit() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(73_529_411u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -657,7 +657,7 @@ fn test_short_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::zero(),
@@ -676,7 +676,7 @@ fn test_short_position_complete_liquidation() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(40_336_134u128),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -755,7 +755,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -774,7 +774,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -793,7 +793,7 @@ fn test_force_error_position_not_liquidation_twap_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -899,7 +899,7 @@ fn test_force_error_position_not_liquidation_spot_over_maintenance_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(20_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::zero(),
@@ -1034,7 +1034,7 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1046,7 +1046,7 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     // alice get: 90.9090909091 - 83.3333333333 = 7.5757575758
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1056,7 +1056,7 @@ fn test_partially_liquidate_one_position_within_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1143,7 +1143,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // actual margin ratio is 19.99...9%
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1154,7 +1154,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // AMM after: quote = 1150
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1165,7 +1165,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // AMM after: quote = 1200
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1176,7 +1176,7 @@ fn test_partially_liquidate_two_positions_within_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1271,7 +1271,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // actual margin ratio is 19.99...9%
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1282,7 +1282,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // AMM after: quote = 1150
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1293,7 +1293,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // AMM after: quote = 1200
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1305,7 +1305,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // alice + carol + david get: 90.9090909091 - 82.6446281 = 8.2644628091
     env.open_small_position(
         env.david.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(400_000u128), // 0.4
         Uint128::from(5_000_000u64),
         400_000u128,
@@ -1315,7 +1315,7 @@ fn test_partially_liquidate_three_positions_within_fluctuation_limit() {
     // AMM after: 1110 : 90.09009009, price: 12.321
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1419,7 +1419,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1430,7 +1430,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: quote = 1150 : 86.9565217391
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1441,7 +1441,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: quote = 1200
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1453,7 +1453,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // alice + carol + david get: 90.9090909091 - 80 = 10.9090909091
     env.open_small_position(
         env.david.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(2_000_000u64),
         Uint128::from(5_000_000u64),
         2_000_000u128,
@@ -1463,7 +1463,7 @@ fn test_partially_liquidate_two_positions_and_completely_liquidate_one_within_fl
     // AMM after: 1150 : 86.9565217391, price: 13.225
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1562,7 +1562,7 @@ fn test_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1574,7 +1574,7 @@ fn test_liquidate_one_position_exceeding_fluctuation_limit() {
     // alice get: 90.9090909091 - 83.3333333333 = 7.5757575758
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1584,7 +1584,7 @@ fn test_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1665,7 +1665,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1677,7 +1677,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
     // alice get: 90.9090909091 - 83.3333333333 = 7.5757575758
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1687,7 +1687,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(4_000_000u64),
         Uint128::from(5_000_000u64),
         4_000_000u128,
@@ -1710,7 +1710,7 @@ fn test_partially_liquidate_one_position_exceeding_fluctuation_limit() {
         .engine
         .open_position(
             env.vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(44_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::zero(),
@@ -1810,7 +1810,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(10_000_000u64),
         Uint128::from(5_000_000u64),
         10_000_000u128,
@@ -1821,7 +1821,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1150 : 86.9565217391
     env.open_small_position(
         env.carol.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(5_000_000u64),
         Uint128::from(5_000_000u64),
         5_000_000u128,
@@ -1833,7 +1833,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1200 : 83.3333333, price: 14.4
     env.open_small_position(
         env.alice.clone(),
-        Side::BUY,
+        Side::Buy,
         Uint128::from(5_000_000u64),
         Uint128::from(5_000_000u64),
         5_000_000u128,
@@ -1843,7 +1843,7 @@ fn test_force_error_partially_liquidate_two_positions_exceeding_fluctuation_limi
     // AMM after: 1100 : 90.9090909091, price: 12.1
     env.open_small_position(
         env.bob.clone(),
-        Side::SELL,
+        Side::Sell,
         Uint128::from(10_000_000u64),
         Uint128::from(5_000_000u64),
         10_000_000u128,

--- a/contracts/margined_engine/src/testing/native_token_pay_funding_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_pay_funding_tests.rs
@@ -23,7 +23,7 @@ fn test_generate_loss_for_amm_when_funding_rate_is_positive_and_amm_is_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -35,7 +35,7 @@ fn test_generate_loss_for_amm_when_funding_rate_is_positive_and_amm_is_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -126,7 +126,7 @@ fn test_will_keep_generating_same_loss_when_funding_rate_is_positive() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -138,7 +138,7 @@ fn test_will_keep_generating_same_loss_when_funding_rate_is_positive() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -212,7 +212,7 @@ fn test_funding_rate_is_1_percent_then_negative_1_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -224,7 +224,7 @@ fn test_funding_rate_is_1_percent_then_negative_1_percent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -330,7 +330,7 @@ fn test_have_huge_funding_payment_profit_withdraw_excess_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -342,7 +342,7 @@ fn test_have_huge_funding_payment_profit_withdraw_excess_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -409,7 +409,7 @@ fn test_have_huge_funding_payment_margin_zero_with_bad_debt() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -421,7 +421,7 @@ fn test_have_huge_funding_payment_margin_zero_with_bad_debt() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -484,7 +484,7 @@ fn test_have_huge_funding_payment_margin_zero_can_add_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -496,7 +496,7 @@ fn test_have_huge_funding_payment_margin_zero_can_add_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -570,7 +570,7 @@ fn test_have_huge_funding_payment_margin_zero_cannot_remove_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -582,7 +582,7 @@ fn test_have_huge_funding_payment_margin_zero_cannot_remove_margin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -644,7 +644,7 @@ fn test_reduce_bad_debt_after_adding_margin_to_an_underwater_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -656,7 +656,7 @@ fn test_reduce_bad_debt_after_adding_margin_to_an_underwater_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),
@@ -734,7 +734,7 @@ fn test_will_change_nothing_if_funding_rate_is_zero() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(300_000_000u128),
             Uint128::from(2_000_000u128),
             Uint128::zero(),
@@ -746,7 +746,7 @@ fn test_will_change_nothing_if_funding_rate_is_zero() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(1200_000_000u128),
             Uint128::from(1_000_000u128),
             Uint128::zero(),

--- a/contracts/margined_engine/src/testing/native_token_position_fee_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_position_fee_tests.rs
@@ -393,7 +393,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(137_878_787u64));
@@ -495,7 +495,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(83_333_334u64));
@@ -598,7 +598,7 @@ fn test_ten_percent_fee_increase_short_position() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -661,7 +661,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(128_571_428u64));
@@ -753,7 +753,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(133_333_334u64));
@@ -842,7 +842,7 @@ fn test_ten_percent_fee_reduce_long_position() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -901,7 +901,7 @@ fn test_ten_percent_fee_reduce_long_position_zero_fee() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -961,7 +961,7 @@ fn test_ten_percent_fee_reduce_short_position() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -1015,7 +1015,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(257_142_857u64));
@@ -1044,7 +1044,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(171_428_572u64));
@@ -1098,7 +1098,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(288_888_889u64));
@@ -1127,7 +1127,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(187_777_778u64));
@@ -1181,7 +1181,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(29_365_079u64));
@@ -1210,7 +1210,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(8_636_787u64));
@@ -1264,7 +1264,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(233_333_333u64));
@@ -1293,7 +1293,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(116_666_667u64));
@@ -1532,7 +1532,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -1589,7 +1589,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(137_878_787u64));
@@ -1624,7 +1624,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -1687,7 +1687,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(83_333_334u64));
@@ -1722,7 +1722,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -1776,7 +1776,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(133_333_334u64));
@@ -1805,7 +1805,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(21u64));
@@ -1860,7 +1860,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_positive(233_333_333u64));

--- a/contracts/margined_engine/src/testing/native_token_position_fee_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_position_fee_tests.rs
@@ -1201,9 +1201,9 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let position: Position = engine
         .position(&router, vamm.addr().to_string(), alice.to_string())
         .unwrap();
-    assert_eq!(position.size, Integer::new_negative(7_352_941u128));
-    assert_eq!(position.notional, Uint128::from(70_728_291u64));
-    assert_eq!(position.margin, Uint128::from(79_271_709u64));
+    assert_eq!(position.size, Integer::new_negative(7_352_942u128));
+    assert_eq!(position.notional, Uint128::from(70_728_290u64));
+    assert_eq!(position.margin, Uint128::from(79_271_710u64));
 
     let pnl = engine
         .get_unrealized_pnl(
@@ -1213,7 +1213,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
             PnlCalcOption::SpotPrice,
         )
         .unwrap();
-    assert_eq!(pnl.unrealized_pnl, Integer::new_negative(8_636_787u64));
+    assert_eq!(pnl.unrealized_pnl, Integer::new_negative(8_636_799u64));
 }
 
 #[test]
@@ -1615,7 +1615,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let position: Position = engine
         .position(&router, vamm.addr().to_string(), alice.to_string())
         .unwrap();
-    assert_eq!(position.size, Integer::new_negative(42_500_000u64));
+    assert_eq!(position.size, Integer::new_negative(42_500_001u64));
     assert_eq!(position.notional, Uint128::from(412_121_213u64));
     assert_eq!(position.margin, Uint128::from(51_515_151u64));
 
@@ -1627,7 +1627,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
             PnlCalcOption::SpotPrice,
         )
         .unwrap();
-    assert_eq!(pnl.unrealized_pnl, Integer::zero());
+    assert_eq!(pnl.unrealized_pnl, Integer::new_negative(9u64));
 
     let fee_pool_balance = router
         .wrap()
@@ -1713,7 +1713,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let position: Position = engine
         .position(&router, vamm.addr().to_string(), alice.to_string())
         .unwrap();
-    assert_eq!(position.size, Integer::new_negative(130_000_000u64));
+    assert_eq!(position.size, Integer::new_negative(130_000_001u64));
     assert_eq!(position.notional, Uint128::from(433_333_334u64));
     assert_eq!(position.margin, Uint128::from(43_333_333u64));
 
@@ -1725,7 +1725,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
             PnlCalcOption::SpotPrice,
         )
         .unwrap();
-    assert_eq!(pnl.unrealized_pnl, Integer::zero());
+    assert_eq!(pnl.unrealized_pnl, Integer::new_negative(3u64));
 }
 
 #[test]
@@ -1886,7 +1886,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let position: Position = engine
         .position(&router, vamm.addr().to_string(), alice.to_string())
         .unwrap();
-    assert_eq!(position.size, Integer::new_positive(50_000_000u64));
+    assert_eq!(position.size, Integer::new_positive(49_999_999u64));
     assert_eq!(position.notional, Uint128::from(333_333_333u64));
     assert_eq!(position.margin, Uint128::from(33_333_333u64));
 }

--- a/contracts/margined_engine/src/testing/native_token_position_fee_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_position_fee_tests.rs
@@ -53,7 +53,7 @@ fn test_force_error_open_position_no_token_sent() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_500_000u64),
@@ -92,7 +92,7 @@ fn test_ten_percent_fee_open_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_500_000u64),
@@ -148,7 +148,7 @@ fn test_force_error_insufficient_token_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_500_000u64),
@@ -186,7 +186,7 @@ fn test_ten_percent_fee_open_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(150_000_000u64),
@@ -244,7 +244,7 @@ fn test_force_error_insufficient_token_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(150_000_000u64),
@@ -282,7 +282,7 @@ fn test_ten_percent_fee_increase_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(20_000_000u64),
@@ -299,7 +299,7 @@ fn test_ten_percent_fee_increase_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(175_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(17_500_000u64),
@@ -362,7 +362,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(20_000_000u64),
@@ -379,7 +379,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(35_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(17_500_000u64),
@@ -403,7 +403,7 @@ fn test_ten_percent_fee_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(200_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(12_500_000u64),
@@ -462,7 +462,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(125_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(20_000_000u64),
@@ -478,7 +478,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(125_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(20_000_000u64),
@@ -505,7 +505,7 @@ fn test_ten_percent_fee_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(20_000_000u64),
@@ -553,7 +553,7 @@ fn test_ten_percent_fee_increase_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(25_000_000u64),
@@ -569,7 +569,7 @@ fn test_ten_percent_fee_increase_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(50_000_000u64),
             Uint128::from(8_000_000u64),
             Uint128::from(125_000_000u64),
@@ -628,7 +628,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(25_000_000u64),
@@ -644,7 +644,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(150_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(75_000_000u64),
@@ -671,7 +671,7 @@ fn test_ten_percent_fee_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(3_000_000u64),
             Uint128::from(300_000_000u64),
@@ -720,7 +720,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(200_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(25_000_000u64),
@@ -736,7 +736,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(200_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(25_000_000u64),
@@ -763,7 +763,7 @@ fn test_ten_percent_fee_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(50_000_000u64),
             Uint128::from(4_000_000u64),
             Uint128::from(25_000_000u64),
@@ -809,7 +809,7 @@ fn test_ten_percent_fee_reduce_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_500_000u64),
@@ -821,7 +821,7 @@ fn test_ten_percent_fee_reduce_long_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(350_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(17_500_000u64),
@@ -868,7 +868,7 @@ fn test_ten_percent_fee_reduce_long_position_zero_fee() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_500_000u64),
@@ -880,7 +880,7 @@ fn test_ten_percent_fee_reduce_long_position_zero_fee() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(350_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(17_500_000u64),
@@ -928,7 +928,7 @@ fn test_ten_percent_fee_reduce_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(150_000_000u64),
@@ -940,7 +940,7 @@ fn test_ten_percent_fee_reduce_short_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(400_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(125_000_000u64),
@@ -989,7 +989,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_500_000u64),
@@ -1001,7 +1001,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(400_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(12_500_000u64),
@@ -1023,7 +1023,7 @@ fn test_ten_percent_fee_reduce_long_position_price_up_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(400_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(12_500_000u64),
@@ -1072,7 +1072,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(500_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(50_000_000u64),
@@ -1084,7 +1084,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(400_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(12_500_000u64),
@@ -1106,7 +1106,7 @@ fn test_ten_percent_fee_reduce_long_position_price_down_long_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(350_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(17_500_000u64),
@@ -1155,7 +1155,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(25_000_000u64),
@@ -1167,7 +1167,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(7_350_000u64),
@@ -1189,7 +1189,7 @@ fn test_ten_percent_fee_reduce_short_position_price_up_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(150_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(17_640_000u64),
@@ -1238,7 +1238,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(250_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(100_000_000u64),
@@ -1250,7 +1250,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(50_000_000u64),
@@ -1272,7 +1272,7 @@ fn test_ten_percent_fee_reduce_short_position_price_down_short_again() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(100_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(50_000_000u64),
@@ -1319,7 +1319,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(20_000_000u64),
@@ -1333,7 +1333,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(250_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(20_000_000u64),
@@ -1377,7 +1377,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(25_000_000u64),
@@ -1391,7 +1391,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_manually() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(200_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(25_000_000u64),
@@ -1434,7 +1434,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(125_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(20_000_000u64),
@@ -1448,7 +1448,7 @@ fn test_ten_percent_fee_open_long_price_remains_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(45_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(45_000_000u64),
@@ -1491,7 +1491,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(20_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(25_000_000u64),
@@ -1505,7 +1505,7 @@ fn test_ten_percent_fee_open_short_price_remains_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(90_000_000u64),
             Uint128::from(5_000_000u64),
             Uint128::from(45_000_000u64),
@@ -1561,7 +1561,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(25_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(20_000_000u64),
@@ -1575,7 +1575,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(35_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(17_500_000u64),
@@ -1597,7 +1597,7 @@ fn test_ten_percent_fee_open_long_price_up_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(8_000_000u64),
             Uint128::from(62_510_000u64),
@@ -1659,7 +1659,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(125_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(20_000_000u64),
@@ -1673,7 +1673,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(125_000_000u64),
             Uint128::from(2_000_000u64),
             Uint128::from(20_000_000u64),
@@ -1695,7 +1695,7 @@ fn test_ten_percent_fee_open_long_price_down_close_opening_larger_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(1_450_000_000u64),
@@ -1750,7 +1750,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(200_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(25_000_000u64),
@@ -1762,7 +1762,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(50_000_000u64),
             Uint128::from(4_000_000u64),
             Uint128::from(7_349_000u64),
@@ -1784,7 +1784,7 @@ fn test_ten_percent_fee_open_short_price_up_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(37_490_000u64),
@@ -1832,7 +1832,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(500_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(100_000_000u64),
@@ -1846,7 +1846,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(100_000_000u64),
             Uint128::from(1_000_000u64),
             Uint128::from(50_000_000u64),
@@ -1868,7 +1868,7 @@ fn test_ten_percent_fee_open_short_price_down_close_opening_larger_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             Uint128::from(60_000_000u64),
             Uint128::from(10_000_000u64),
             Uint128::from(149_990_000u64),

--- a/contracts/margined_engine/src/testing/open_notional_tests.rs
+++ b/contracts/margined_engine/src/testing/open_notional_tests.rs
@@ -38,7 +38,7 @@ fn test_increase_with_increase_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(600u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -85,7 +85,7 @@ fn test_reduce_when_position_is_reduced() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(600u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -97,7 +97,7 @@ fn test_reduce_when_position_is_reduced() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(300u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -144,7 +144,7 @@ fn test_reduce_when_close_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(400u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -211,7 +211,7 @@ fn test_increase_when_traders_open_positions_in_diff_directions() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -223,7 +223,7 @@ fn test_increase_when_traders_open_positions_in_diff_directions() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(300u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -270,7 +270,7 @@ fn test_increase_when_traders_open_larger_positions_in_reverse_directions() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -282,7 +282,7 @@ fn test_increase_when_traders_open_larger_positions_in_reverse_directions() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(450u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -344,7 +344,7 @@ fn test_zero_when_everyone_closes_positions() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -356,7 +356,7 @@ fn test_zero_when_everyone_closes_positions() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -428,7 +428,7 @@ fn test_zero_when_everyone_closes_positions_one_position_is_bankrupt() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -440,7 +440,7 @@ fn test_zero_when_everyone_closes_positions_one_position_is_bankrupt() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -521,7 +521,7 @@ fn test_stop_trading_if_over_open_interest_notional_cap() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(600u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -533,7 +533,7 @@ fn test_stop_trading_if_over_open_interest_notional_cap() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(1u64),
             to_decimals(1u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/pausable_tests.rs
+++ b/contracts/margined_engine/src/testing/pausable_tests.rs
@@ -19,7 +19,7 @@ fn test_paused_by_admin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(1u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -97,7 +97,7 @@ fn test_pause_then_unpause_by_admin() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(1u64),
             to_decimals(1u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/personal_position_tests.rs
+++ b/contracts/margined_engine/src/testing/personal_position_tests.rs
@@ -38,7 +38,7 @@ fn test_get_personal_position_with_funding_payments() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/position_liquidation_tests.rs
+++ b/contracts/margined_engine/src/testing/position_liquidation_tests.rs
@@ -50,7 +50,7 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_l
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -62,7 +62,7 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_l
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -151,7 +151,7 @@ fn test_alice_has_enough_margin_cant_get_liquidated() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -163,7 +163,7 @@ fn test_alice_has_enough_margin_cant_get_liquidated() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(500u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -235,7 +235,7 @@ fn test_alice_gets_liquidated_insufficient_margin_for_liquidation_fee() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(150u64),
             to_decimals(4u64),
             to_decimals(0u64),
@@ -247,7 +247,7 @@ fn test_alice_gets_liquidated_insufficient_margin_for_liquidation_fee() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(500u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -317,7 +317,7 @@ fn test_alice_gets_liquidated_insufficient_margin_for_liquidation_fee() {
 //     let msg = engine
 //         .open_position(
 //             vamm.addr().to_string(),
-//             Side::BUY,
+//             Side::Buy,
 //             to_decimals(150u64),
 //             to_decimals(4u64),
 // to_decimals(0u64),
@@ -331,7 +331,7 @@ fn test_alice_gets_liquidated_insufficient_margin_for_liquidation_fee() {
 //     // let msg = engine
 //     //     .open_position(
 //     //         vamm.addr().to_string(),
-//     //         Side::SELL,
+//     //         Side::Sell,
 //     //         to_decimals(500u64),
 //     //         to_decimals(1u64),
 // to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/position_tests.rs
+++ b/contracts/margined_engine/src/testing/position_tests.rs
@@ -43,7 +43,7 @@ fn test_get_all_positions_open_position_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -84,7 +84,7 @@ fn test_open_position_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -124,7 +124,7 @@ fn test_open_position_two_longs() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -136,7 +136,7 @@ fn test_open_position_two_longs() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -171,7 +171,7 @@ fn test_open_position_two_shorts() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(40u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -183,7 +183,7 @@ fn test_open_position_two_shorts() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(40u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -219,7 +219,7 @@ fn test_open_position_equal_size_opposite_side() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -231,7 +231,7 @@ fn test_open_position_equal_size_opposite_side() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(300u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -267,7 +267,7 @@ fn test_open_position_one_long_two_shorts() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -279,7 +279,7 @@ fn test_open_position_one_long_two_shorts() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(5u64),
             to_decimals(0u64),
@@ -298,7 +298,7 @@ fn test_open_position_one_long_two_shorts() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(50u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -334,7 +334,7 @@ fn test_open_position_short_and_two_longs() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(40u64),
             to_decimals(5u64),
             to_decimals(25u64),
@@ -353,7 +353,7 @@ fn test_open_position_short_and_two_longs() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(5u64),
             Uint128::from(13_800_000_000u128),
@@ -383,7 +383,7 @@ fn test_open_position_short_and_two_longs() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(10u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -413,7 +413,7 @@ fn test_open_position_short_long_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -425,7 +425,7 @@ fn test_open_position_short_long_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(150u64),
             to_decimals(3u64),
             to_decimals(0u64),
@@ -443,7 +443,7 @@ fn test_open_position_short_long_short() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -473,7 +473,7 @@ fn test_open_position_long_short_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -485,7 +485,7 @@ fn test_open_position_long_short_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(150u64),
             to_decimals(3u64),
             to_decimals(0u64),
@@ -502,7 +502,7 @@ fn test_open_position_long_short_long() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -532,7 +532,7 @@ fn test_pnl_zero_no_others_trading() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -544,7 +544,7 @@ fn test_pnl_zero_no_others_trading() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(750u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -579,7 +579,7 @@ fn test_close_safe_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(50u64),
             to_decimals(2u64),
             to_decimals(0u64),
@@ -597,7 +597,7 @@ fn test_close_safe_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(10u64),
             to_decimals(6u64),
             to_decimals(0u64),
@@ -648,7 +648,7 @@ fn test_close_position_over_maintenance_margin_ration() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -665,7 +665,7 @@ fn test_close_position_over_maintenance_margin_ration() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             Uint128::from(35_080_000_000u128),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -708,7 +708,7 @@ fn test_close_under_collateral_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -725,7 +725,7 @@ fn test_close_under_collateral_position() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(250u64),
             to_decimals(1u64),
             to_decimals(0u64),
@@ -816,7 +816,7 @@ fn test_openclose_position_to_check_fee_is_charged() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -863,7 +863,7 @@ fn test_pnl_unrealized() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(25u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -885,7 +885,7 @@ fn test_pnl_unrealized() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(100u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -948,7 +948,7 @@ fn test_error_open_position_insufficient_balance() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -960,7 +960,7 @@ fn test_error_open_position_insufficient_balance() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -987,7 +987,7 @@ fn test_error_open_position_exceed_margin_ratio() {
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::BUY,
+            Side::Buy,
             to_decimals(60u64),
             to_decimals(21u64),
             to_decimals(0u64),
@@ -1045,7 +1045,7 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_c
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),
@@ -1057,7 +1057,7 @@ fn test_alice_take_profit_from_bob_unrealized_undercollateralized_position_bob_c
     let msg = engine
         .open_position(
             vamm.addr().to_string(),
-            Side::SELL,
+            Side::Sell,
             to_decimals(20u64),
             to_decimals(10u64),
             to_decimals(0u64),

--- a/contracts/margined_engine/src/testing/position_tests.rs
+++ b/contracts/margined_engine/src/testing/position_tests.rs
@@ -367,7 +367,7 @@ fn test_open_position_short_and_two_longs() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::new_negative(8u64));
@@ -558,7 +558,7 @@ fn test_pnl_zero_no_others_trading() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(pnl.unrealized_pnl, Integer::zero());
@@ -911,7 +911,7 @@ fn test_pnl_unrealized() {
             &router,
             vamm.addr().to_string(),
             alice.to_string(),
-            PnlCalcOption::SPOTPRICE,
+            PnlCalcOption::SpotPrice,
         )
         .unwrap();
     assert_eq!(

--- a/contracts/margined_engine/src/utils.rs
+++ b/contracts/margined_engine/src/utils.rs
@@ -294,15 +294,15 @@ pub fn require_not_paused(paused: bool) -> StdResult<Response> {
 // takes the side (buy|sell) and returns the direction (long|short)
 pub fn side_to_direction(side: Side) -> Direction {
     match side {
-        Side::BUY => Direction::AddToAmm,
-        Side::SELL => Direction::RemoveFromAmm,
+        Side::Buy => Direction::AddToAmm,
+        Side::Sell => Direction::RemoveFromAmm,
     }
 }
 
 // takes the direction (long|short) and returns the side (buy|sell)
 pub fn direction_to_side(direction: Direction) -> Side {
     match direction {
-        Direction::AddToAmm => Side::BUY,
-        Direction::RemoveFromAmm => Side::SELL,
+        Direction::AddToAmm => Side::Buy,
+        Direction::RemoveFromAmm => Side::Sell,
     }
 }

--- a/contracts/margined_engine/src/utils.rs
+++ b/contracts/margined_engine/src/utils.rs
@@ -118,7 +118,7 @@ pub fn get_position_notional_unrealized_pnl(
     let position_size = position.size;
     if !position_size.is_zero() {
         match calc_option {
-            PnlCalcOption::TWAP => {
+            PnlCalcOption::Twap => {
                 output_notional = query_vamm_output_twap(
                     &deps,
                     position.vamm.to_string(),
@@ -126,7 +126,7 @@ pub fn get_position_notional_unrealized_pnl(
                     position_size.value,
                 )?;
             }
-            PnlCalcOption::SPOTPRICE => {
+            PnlCalcOption::SpotPrice => {
                 output_notional = query_vamm_output_price(
                     &deps,
                     position.vamm.to_string(),
@@ -134,7 +134,7 @@ pub fn get_position_notional_unrealized_pnl(
                     position_size.value,
                 )?;
             }
-            PnlCalcOption::ORACLE => {}
+            PnlCalcOption::Oracle => {}
         }
 
         // we are short if the size of the position is less than 0

--- a/contracts/margined_vamm/src/handle.rs
+++ b/contracts/margined_vamm/src/handle.rs
@@ -315,7 +315,7 @@ pub fn get_input_price_with_reserves(
         base_asset_reserve - base_asset_after
     };
 
-    let remainder = modulo(invariant_k, quote_asset_after);
+    let remainder = modulo(invariant_k, quote_asset_after, config.decimals);
     if remainder != Uint128::zero() {
         if *direction == Direction::AddToAmm {
             base_asset_bought = base_asset_bought.checked_sub(Uint128::new(1u128))?;
@@ -358,7 +358,7 @@ pub fn get_output_price_with_reserves(
         quote_asset_reserve - quote_asset_after
     };
 
-    let remainder = modulo(invariant_k, base_asset_after);
+    let remainder = modulo(invariant_k, base_asset_after, config.decimals);
     if remainder != Uint128::zero() {
         if *direction == Direction::AddToAmm {
             quote_asset_sold = quote_asset_sold.checked_sub(Uint128::from(1u128))?;

--- a/contracts/margined_vamm/src/query.rs
+++ b/contracts/margined_vamm/src/query.rs
@@ -231,6 +231,8 @@ fn calc_twap(deps: Deps, env: Env, interval: u64) -> StdResult<Uint128> {
     Ok(weighted_price.checked_div(Uint128::from(interval))?)
 }
 
+// fn get_price_with_specific_snapshot() {}
+
 // TODO TODO TODO
 // Please clean this function up and amalgamate with that above **IF**
 // possible.

--- a/contracts/margined_vamm/src/utils.rs
+++ b/contracts/margined_vamm/src/utils.rs
@@ -126,12 +126,10 @@ pub fn add_reserve_snapshot(
 }
 
 /// Does the modulus (%) operator on Uint128.
-/// However it follows the design of the perpertual protocol decimals
+/// However it follows the design of the perpetual protocol decimals
 /// https://github.com/perpetual-protocol/perpetual-protocol/blob/release/v2.1.x/src/utils/Decimal.sol
-pub(crate) fn modulo(a: Uint128, b: Uint128) -> Uint128 {
-    // TODO the decimals are currently hardcoded to 9dp, this needs to change in the future but without
-    // needing to pass the entire world to this function, i.e. access to storage
-    let a_decimals = a.checked_mul(Uint128::from(1_000_000_000u128)).unwrap();
+pub(crate) fn modulo(a: Uint128, b: Uint128, decimals: Uint128) -> Uint128 {
+    let a_decimals = a.checked_mul(decimals).unwrap();
     let integral = a_decimals / b;
     a_decimals - (b * integral)
 }

--- a/packages/margined_perp/src/margined_engine.rs
+++ b/packages/margined_perp/src/margined_engine.rs
@@ -15,9 +15,9 @@ pub enum Side {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PnlCalcOption {
-    SPOTPRICE,
-    TWAP,
-    ORACLE,
+    SpotPrice,
+    Twap,
+    Oracle,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/margined_perp/src/margined_engine.rs
+++ b/packages/margined_perp/src/margined_engine.rs
@@ -8,8 +8,8 @@ use terraswap::asset::AssetInfo;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Side {
-    BUY,
-    SELL,
+    Buy,
+    Sell,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
This PR makes a small number of fixes to the code:

* Rename enums BUY, SELL, etc so that they are not `b_u_y` in the external interface
* Removed hardcoded decimals from the modulo function in the vamm