### PR TITLE
Fix/audit-27/check-funds-sent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
+ "cw-utils",
  "cw20",
  "schemars",
  "serde",

--- a/contracts/margined_engine/src/contract.rs
+++ b/contracts/margined_engine/src/contract.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = "margin-engine";
+const CONTRACT_NAME: &str = "crates.io:margined-engine";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
@@ -98,7 +98,7 @@ fn test_force_error_add_incorrect_margin() {
     let err = router.execute(alice.clone(), msg).unwrap_err();
     assert_eq!(
         StdError::GenericErr {
-            msg: "Must send reserve token uwasm".to_string(),
+            msg: "Must send reserve token 'uwasm'".to_string(),
         },
         err.downcast().unwrap()
     );

--- a/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
@@ -1,6 +1,9 @@
-use cosmwasm_std::{BankMsg, Coin, CosmosMsg, StdError, Uint128};
+use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg, MessageInfo, StdError, Uint128};
 use cw_multi_test::Executor;
-use margined_common::integer::Integer;
+use margined_common::{
+    asset::{Asset, AssetInfo},
+    integer::Integer,
+};
 use margined_perp::margined_engine::Side;
 use margined_utils::scenarios::NativeTokenScenario;
 

--- a/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
@@ -98,8 +98,7 @@ fn test_force_error_add_incorrect_margin() {
     let err = router.execute(alice.clone(), msg).unwrap_err();
     assert_eq!(
         StdError::GenericErr {
-            msg: "Native token balance mismatch between the argument and the transferred"
-                .to_string(),
+            msg: "Must send reserve token uwasm".to_string(),
         },
         err.downcast().unwrap()
     );

--- a/contracts/margined_fee_pool/src/contract.rs
+++ b/contracts/margined_fee_pool/src/contract.rs
@@ -13,7 +13,7 @@ use cw2::set_contract_version;
 use margined_perp::margined_fee_pool::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = "fee-pool";
+const CONTRACT_NAME: &str = "crates.io:margined-fee-pool";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -14,7 +14,7 @@ use cw2::set_contract_version;
 use margined_perp::margined_insurance_fund::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = "insurance-fund";
+const CONTRACT_NAME: &str = "crates.io:margined-insurance-fund";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/contracts/margined_pricefeed/src/contract.rs
+++ b/contracts/margined_pricefeed/src/contract.rs
@@ -12,7 +12,7 @@ use cosmwasm_std::{
 use margined_perp::margined_pricefeed::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = "pricefeed";
+const CONTRACT_NAME: &str = "crates.io:margined-pricefeed";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/contracts/margined_vamm/src/contract.rs
+++ b/contracts/margined_vamm/src/contract.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = "crates.io:margined-virtual-amm";
+const CONTRACT_NAME: &str = "crates.io:margined-vamm";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/contracts/margined_vamm/src/contract.rs
+++ b/contracts/margined_vamm/src/contract.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = "virtual-amm";
+const CONTRACT_NAME: &str = "crates.io:margined-virtual-amm";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/packages/margined_common/Cargo.toml
+++ b/packages/margined_common/Cargo.toml
@@ -14,6 +14,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cw20 = { version = "0.13.2" }
+cw-utils = "0.13.4"
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
 schemars = "0.8.1"

--- a/packages/margined_common/src/asset.rs
+++ b/packages/margined_common/src/asset.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
     QueryRequest, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 use cw20::{Cw20ExecuteMsg, Cw20QueryMsg, TokenInfoResponse};
-use cw_utils::{must_pay, PaymentError};
+use cw_utils::must_pay;
 
 /// ## Description
 /// This enum describes a Terra asset (native or CW20).
@@ -72,28 +72,6 @@ impl Asset {
     /// * **self** is the type of the caller object.
     ///
     /// * **message_info** is an object of type [`MessageInfo`]
-    // pub fn assert_sent_native_token_balance(&self, message_info: &MessageInfo) -> StdResult<()> {
-    //     if let AssetInfo::NativeToken { denom } = &self.info {
-    //         match message_info.funds.iter().find(|x| x.denom == *denom) {
-    //             Some(coin) => {
-    //                 if self.amount == coin.amount {
-    //                     Ok(())
-    //                 } else {
-    //                     Err(StdError::generic_err("Native token balance mismatch between the argument and the transferred"))
-    //                 }
-    //             }
-    //             None => {
-    //                 if self.amount.is_zero() {
-    //                     Ok(())
-    //                 } else {
-    //                     Err(StdError::generic_err("Native token balance mismatch between the argument and the transferred"))
-    //                 }
-    //             }
-    //         }
-    //     } else {
-    //         Ok(())
-    //     }
-    // }
     pub fn assert_sent_native_token_balance(&self, message_info: &MessageInfo) -> StdResult<()> {
         let msg_amount: Uint128;
 

--- a/packages/margined_common/src/asset.rs
+++ b/packages/margined_common/src/asset.rs
@@ -100,30 +100,8 @@ impl Asset {
         // grab the denom from self so we can test
         if let AssetInfo::NativeToken { denom } = &self.info {
             // call `must_pay` to ensure its the right denom
-            msg_amount = match must_pay(message_info, denom) {
-                Ok(amount) => amount,
-                Err(e) => match e {
-                    PaymentError::MissingDenom(string) => {
-                        return Err(StdError::generic_err(format!(
-                            "Must send reserve token {}",
-                            string
-                        )))
-                    }
-                    PaymentError::ExtraDenom(string) => {
-                        return Err(StdError::generic_err(format!(
-                            "Received unsupported denom {}",
-                            string
-                        )))
-                    }
-                    PaymentError::MultipleDenoms {} => {
-                        return Err(StdError::generic_err("Sent more than one denomination"))
-                    }
-                    PaymentError::NoFunds {} => return Err(StdError::generic_err("No funds sent")),
-                    PaymentError::NonPayable {} => {
-                        return Err(StdError::generic_err("This message does not accept funds"))
-                    }
-                },
-            };
+            msg_amount = must_pay(message_info, denom)
+                .map_err(|error| StdError::generic_err(format!("{}", error)))?
         } else {
             return Err(StdError::generic_err("You did not send Native Token"));
         };

--- a/packages/margined_common/src/asset.rs
+++ b/packages/margined_common/src/asset.rs
@@ -10,7 +10,7 @@ use cw20::{Cw20ExecuteMsg, Cw20QueryMsg, TokenInfoResponse};
 use cw_utils::must_pay;
 
 /// ## Description
-/// This enum describes a Terra asset (native or CW20).
+/// This enum describes a Cosmos asset (native or CW20).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Asset {
     /// Information about an asset stored in a [`AssetInfo`] struct
@@ -77,11 +77,12 @@ impl Asset {
 
         // grab the denom from self so we can test
         if let AssetInfo::NativeToken { denom } = &self.info {
-            // call `must_pay` to ensure its the right denom
+            // call `must_pay` to ensure its the right denom + funds are sent
             msg_amount = must_pay(message_info, denom)
                 .map_err(|error| StdError::generic_err(format!("{}", error)))?
         } else {
-            return Err(StdError::generic_err("You did not send Native Token"));
+            // this error occurs if self is of type `AssetInfo::Token`
+            return Err(StdError::generic_err("self is not native token"));
         };
 
         if self.amount == msg_amount {


### PR DESCRIPTION
- Changed the contract names to be more compliant with namespacing standards as per audit 28
- Modified the `assert_sent_native_token_balance` balance to ensure that people *only* send the right token as well as the tests on 'amount'