### PR TITLE
Fix/audit 21/remove sender validation

### DIFF
--- a/contracts/margined_engine/src/contract.rs
+++ b/contracts/margined_engine/src/contract.rs
@@ -53,6 +53,7 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     // validate message addresses
+    let pauser = deps.api.addr_validate(&msg.pauser)?;
     let insurance_fund = deps.api.addr_validate(&msg.insurance_fund)?;
     let fee_pool = deps.api.addr_validate(&msg.fee_pool)?;
 
@@ -76,6 +77,7 @@ pub fn instantiate(
     // config parameters
     let config = Config {
         owner: info.sender,
+        pauser,
         insurance_fund,
         fee_pool,
         eligible_collateral,
@@ -106,6 +108,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
     match msg {
         ExecuteMsg::UpdateConfig {
             owner,
+            pauser,
             insurance_fund,
             fee_pool,
             eligible_collateral,
@@ -117,6 +120,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             deps,
             info,
             owner,
+            pauser,
             insurance_fund,
             fee_pool,
             eligible_collateral,

--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -63,7 +63,7 @@ pub fn update_config(
         config.owner = deps.api.addr_validate(owner.as_str())?;
     }
 
-    // change owner of engine
+    // change pauser role
     if let Some(pauser) = pauser {
         config.pauser = deps.api.addr_validate(pauser.as_str())?;
     }

--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -42,6 +42,7 @@ pub fn update_config(
     deps: DepsMut,
     info: MessageInfo,
     owner: Option<String>,
+    pauser: Option<String>,
     insurance_fund: Option<String>,
     fee_pool: Option<String>,
     eligible_collateral: Option<String>,
@@ -60,6 +61,11 @@ pub fn update_config(
     // change owner of engine
     if let Some(owner) = owner {
         config.owner = deps.api.addr_validate(owner.as_str())?;
+    }
+
+    // change owner of engine
+    if let Some(pauser) = pauser {
+        config.pauser = deps.api.addr_validate(pauser.as_str())?;
     }
 
     // update insurance fund - note altering insurance fund could lead to vAMMs being unusable maybe make this a migration
@@ -123,7 +129,7 @@ pub fn set_pause(deps: DepsMut, _env: Env, info: MessageInfo, pause: bool) -> St
     let mut state: State = read_state(deps.storage)?;
 
     // check permission and if state matches
-    if info.sender != config.owner || state.pause == pause {
+    if info.sender != config.pauser || state.pause == pause {
         return Err(StdError::generic_err("unauthorized"));
     }
 
@@ -151,7 +157,7 @@ pub fn open_position(
 
     // validate address inputs
     let vamm = deps.api.addr_validate(&vamm)?;
-    let trader = deps.api.addr_validate(info.sender.as_ref())?;
+    let trader = info.sender.clone();
 
     require_not_paused(state.pause)?;
     require_vamm(deps.as_ref(), &config.insurance_fund, &vamm)?;
@@ -250,7 +256,7 @@ pub fn close_position(
 
     // validate address inputs
     let vamm = deps.api.addr_validate(&vamm)?;
-    let trader = deps.api.addr_validate(info.sender.as_ref())?;
+    let trader = info.sender;
 
     // read the position for the trader from vamm
     let position = read_position(deps.storage, &vamm, &trader).unwrap();

--- a/contracts/margined_engine/src/query.rs
+++ b/contracts/margined_engine/src/query.rs
@@ -19,6 +19,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 
     Ok(ConfigResponse {
         owner: config.owner,
+        pauser: config.pauser,
         insurance_fund: config.insurance_fund,
         fee_pool: config.fee_pool,
         eligible_collateral: config.eligible_collateral,

--- a/contracts/margined_engine/src/state.rs
+++ b/contracts/margined_engine/src/state.rs
@@ -26,6 +26,7 @@ pub static KEY_VAMM_MAP: &[u8] = b"vamm-map";
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Config {
     pub owner: Addr,
+    pub pauser: Addr,
     pub insurance_fund: Addr,
     pub fee_pool: Addr,
     pub eligible_collateral: AssetInfo,

--- a/contracts/margined_engine/src/testing/tests.rs
+++ b/contracts/margined_engine/src/testing/tests.rs
@@ -31,6 +31,7 @@ fn test_instantiation() {
         config,
         ConfigResponse {
             owner: info.sender,
+            pauser: Addr::unchecked(OWNER.to_string()),
             insurance_fund: Addr::unchecked(INSURANCE_FUND.to_string()),
             fee_pool: Addr::unchecked(FEE_POOL.to_string()),
             eligible_collateral: AssetInfo::NativeToken {
@@ -82,6 +83,7 @@ fn test_update_config() {
         config,
         ConfigResponse {
             owner: Addr::unchecked("addr0001".to_string()),
+            pauser: Addr::unchecked(OWNER.to_string()),
             insurance_fund: Addr::unchecked(INSURANCE_FUND.to_string()),
             fee_pool: Addr::unchecked(FEE_POOL.to_string()),
             eligible_collateral: AssetInfo::NativeToken {

--- a/contracts/margined_engine/src/testing/tests.rs
+++ b/contracts/margined_engine/src/testing/tests.rs
@@ -13,6 +13,7 @@ const FEE_POOL: &str = "fee_pool";
 fn test_instantiation() {
     let mut deps = mock_dependencies();
     let msg = InstantiateMsg {
+        pauser: OWNER.to_string(),
         insurance_fund: INSURANCE_FUND.to_string(),
         fee_pool: FEE_POOL.to_string(),
         eligible_collateral: TOKEN.to_string(),
@@ -48,6 +49,7 @@ fn test_instantiation() {
 fn test_update_config() {
     let mut deps = mock_dependencies();
     let msg = InstantiateMsg {
+        pauser: OWNER.to_string(),
         insurance_fund: INSURANCE_FUND.to_string(),
         fee_pool: FEE_POOL.to_string(),
         eligible_collateral: TOKEN.to_string(),
@@ -61,6 +63,7 @@ fn test_update_config() {
     // Update the config
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("addr0001".to_string()),
+        pauser: None,
         insurance_fund: None,
         fee_pool: None,
         eligible_collateral: None,
@@ -95,6 +98,7 @@ fn test_update_config() {
     // Update should fail
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some(OWNER.to_string()),
+        pauser: None,
         insurance_fund: None,
         fee_pool: None,
         eligible_collateral: None,
@@ -111,6 +115,7 @@ fn test_update_config() {
     // Update should fail
     let msg = ExecuteMsg::UpdateConfig {
         owner: None,
+        pauser: None,
         insurance_fund: None,
         fee_pool: None,
         eligible_collateral: None,

--- a/packages/margined_perp/src/margined_engine.rs
+++ b/packages/margined_perp/src/margined_engine.rs
@@ -21,6 +21,7 @@ pub enum PnlCalcOption {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct InstantiateMsg {
+    pub pauser: String,
     pub insurance_fund: String,
     pub fee_pool: String,
     pub eligible_collateral: String,
@@ -34,6 +35,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     UpdateConfig {
         owner: Option<String>,
+        pauser: Option<String>,
         insurance_fund: Option<String>,
         fee_pool: Option<String>,
         eligible_collateral: Option<String>,

--- a/packages/margined_perp/src/margined_engine.rs
+++ b/packages/margined_perp/src/margined_engine.rs
@@ -116,6 +116,7 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ConfigResponse {
     pub owner: Addr,
+    pub pauser: Addr,
     pub insurance_fund: Addr,
     pub fee_pool: Addr,
     pub eligible_collateral: AssetInfo,

--- a/packages/margined_utils/src/contracts/helpers/margined_engine.rs
+++ b/packages/margined_utils/src/contracts/helpers/margined_engine.rs
@@ -36,6 +36,7 @@ impl EngineController {
     pub fn update_config(
         &self,
         owner: Option<String>,
+        pauser: Option<String>,
         insurance_fund: Option<String>,
         fee_pool: Option<String>,
         eligible_collateral: Option<String>,
@@ -46,6 +47,7 @@ impl EngineController {
     ) -> StdResult<CosmosMsg> {
         let msg = ExecuteMsg::UpdateConfig {
             owner,
+            pauser,
             insurance_fund,
             fee_pool,
             eligible_collateral,
@@ -60,6 +62,7 @@ impl EngineController {
     pub fn set_initial_margin_ratio(&self, initial_margin_ratio: Uint128) -> StdResult<CosmosMsg> {
         let msg = ExecuteMsg::UpdateConfig {
             owner: None,
+            pauser: None,
             insurance_fund: None,
             fee_pool: None,
             eligible_collateral: None,
@@ -77,6 +80,7 @@ impl EngineController {
     ) -> StdResult<CosmosMsg> {
         let msg = ExecuteMsg::UpdateConfig {
             owner: None,
+            pauser: None,
             insurance_fund: None,
             fee_pool: None,
             eligible_collateral: None,
@@ -91,6 +95,7 @@ impl EngineController {
     pub fn set_margin_ratios(&self, margin_ratio: Uint128) -> StdResult<CosmosMsg> {
         let msg = ExecuteMsg::UpdateConfig {
             owner: None,
+            pauser: None,
             insurance_fund: None,
             fee_pool: None,
             eligible_collateral: None,
@@ -108,6 +113,7 @@ impl EngineController {
     ) -> StdResult<CosmosMsg> {
         let msg = ExecuteMsg::UpdateConfig {
             owner: None,
+            pauser: None,
             insurance_fund: None,
             fee_pool: None,
             eligible_collateral: None,
@@ -122,6 +128,7 @@ impl EngineController {
     pub fn set_liquidation_fee(&self, liquidation_fee: Uint128) -> StdResult<CosmosMsg> {
         let msg = ExecuteMsg::UpdateConfig {
             owner: None,
+            pauser: None,
             insurance_fund: None,
             fee_pool: None,
             eligible_collateral: None,

--- a/packages/margined_utils/src/scenarios/mod.rs
+++ b/packages/margined_utils/src/scenarios/mod.rs
@@ -162,6 +162,7 @@ impl NativeTokenScenario {
                 engine_id,
                 owner.clone(),
                 &InstantiateMsg {
+                    pauser: owner.to_string(),
                     insurance_fund: insurance_fund.addr().to_string(),
                     fee_pool: fee_pool.addr().to_string(),
                     eligible_collateral: native_denom.to_string(),
@@ -423,6 +424,7 @@ impl SimpleScenario {
                 engine_id,
                 owner.clone(),
                 &InstantiateMsg {
+                    pauser: owner.to_string(),
                     insurance_fund: insurance_fund.addr().to_string(),
                     fee_pool: fee_pool.addr().to_string(),
                     eligible_collateral: usdc_addr.to_string(),


### PR DESCRIPTION
- Removed the validation of info.sender in open and close position
- Added the idea of a pauser role in the config of engine, changed tests + scenarios etc to mirror this (Audit - 20)

Could add some more tests to check specifically that pausing works?