### PR TITLE
removed beta deps

### DIFF
--- a/contracts/margined_engine/Cargo.toml
+++ b/contracts/margined_engine/Cargo.toml
@@ -53,7 +53,7 @@ thiserror = { version = "1.0" }
 sha3 = "0.10.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0" }
 cw20-base = { version = "0.13.2", features = ["library"] }
 margined_utils = { version = "0.1.0", path = "../../packages/margined_utils" }
 margined_vamm = { version = "0.1.0", path = "../../contracts/margined_vamm" }

--- a/contracts/margined_fee_pool/Cargo.toml
+++ b/contracts/margined_fee_pool/Cargo.toml
@@ -52,6 +52,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0" }
 margined_utils = { version = "0.1.0", path = "../../packages/margined_utils" }
 cw-multi-test = "0.13.2"

--- a/contracts/margined_insurance_fund/Cargo.toml
+++ b/contracts/margined_insurance_fund/Cargo.toml
@@ -52,6 +52,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0" }
 margined_utils = { version = "0.1.0", path = "../../packages/margined_utils" }
 cw-multi-test = "0.13.2"

--- a/contracts/margined_pricefeed/Cargo.toml
+++ b/contracts/margined_pricefeed/Cargo.toml
@@ -51,4 +51,4 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0" }

--- a/contracts/margined_vamm/Cargo.toml
+++ b/contracts/margined_vamm/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0" }
 cw20-base = { version = "0.13.2", features = ["library"] }
 margined_utils = { version = "0.1.0", path = "../../packages/margined_utils" }
 margined_engine = { version = "0.1.0", path = "../../contracts/margined_engine" }


### PR DESCRIPTION
just changed the deps version from `1.0.0-beta` to `1.0.0` in the cargo.toml's of each contract