### PR TITLE
added a check when depositing margin into a non-existent posn + tests

### DIFF
--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -397,6 +397,11 @@ pub fn deposit_margin(
 
     // read the position for the trader from vamm
     let mut position = read_position(deps.storage, &vamm, &trader).unwrap();
+
+    if position.trader != trader {
+        return Err(StdError::generic_err("No position found"));
+    }
+
     position.margin = position.margin.checked_add(amount)?;
 
     store_position(deps.storage, &position)?;

--- a/contracts/margined_engine/src/testing/cw_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_add_remove_margin_tests.rs
@@ -107,7 +107,12 @@ fn test_add_margin_no_open_position() {
     let msg = engine
         .deposit_margin(vamm.addr().to_string(), to_decimals(80u64), vec![])
         .unwrap();
-    router.execute(alice.clone(), msg).unwrap();
+    let err = router.execute(alice.clone(), msg).unwrap_err();
+
+    assert_eq!(
+        err.source().unwrap().to_string(),
+        "Generic error: No position found"
+    );
 }
 
 #[test]

--- a/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
+++ b/contracts/margined_engine/src/testing/native_token_add_remove_margin_tests.rs
@@ -124,7 +124,12 @@ fn test_add_margin_no_open_position() {
             vec![Coin::new(80_000_000u128, "uwasm")],
         )
         .unwrap();
-    router.execute(alice.clone(), msg).unwrap();
+    let err = router.execute(alice.clone(), msg).unwrap_err();
+
+    assert_eq!(
+        err.source().unwrap().to_string(),
+        "Generic error: No position found"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Checked if the `read_position` function returns the default position (the position.trader field is an empty string) and errors if that is the case

changed two existing tests to catch this error