### PR TITLE
Fix/audit 9/insurance fund beneficiary

### DIFF
--- a/contracts/margined_engine/src/testing/cw_token_liquidation_frontrun_hack_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_liquidation_frontrun_hack_tests.rs
@@ -923,18 +923,3 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         "Generic error: Only one action allowed".to_string()
     );
 }
-
-#[test]
-fn test_check_config() {
-    let env = SimpleScenario::new();
-
-    // query the beneficiary in insurance fund
-    let config = env.insurance_fund.config(&env.router).unwrap();
-
-    assert_eq!(config.beneficiary, env.engine.addr());
-
-    // query the insurance fund in margine engine
-    let config = env.engine.config(&env.router).unwrap();
-
-    assert_eq!(config.insurance_fund, env.insurance_fund.addr());
-}

--- a/contracts/margined_engine/src/testing/cw_token_liquidation_frontrun_hack_tests.rs
+++ b/contracts/margined_engine/src/testing/cw_token_liquidation_frontrun_hack_tests.rs
@@ -923,3 +923,18 @@ fn test_can_open_position_same_side_and_liquidate_but_cannot_do_anything_more_in
         "Generic error: Only one action allowed".to_string()
     );
 }
+
+#[test]
+fn test_check_config() {
+    let env = SimpleScenario::new();
+
+    // query the beneficiary in insurance fund
+    let config = env.insurance_fund.config(&env.router).unwrap();
+
+    assert_eq!(config.beneficiary, env.engine.addr());
+
+    // query the insurance fund in margine engine
+    let config = env.engine.config(&env.router).unwrap();
+
+    assert_eq!(config.insurance_fund, env.insurance_fund.addr());
+}

--- a/contracts/margined_engine/src/testing/position_tests.rs
+++ b/contracts/margined_engine/src/testing/position_tests.rs
@@ -686,7 +686,7 @@ fn test_close_safe_position() {
 }
 
 #[test]
-fn test_close_position_over_maintenance_margin_ration() {
+fn test_close_position_over_maintenance_margin_ratio() {
     let SimpleScenario {
         mut router,
         alice,

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -45,9 +45,7 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> StdResult<Response> {
     match msg {
-        ExecuteMsg::UpdateConfig { owner, beneficiary } => {
-            update_config(deps, info, owner, beneficiary)
-        }
+        ExecuteMsg::UpdateConfig { owner } => update_config(deps, info, owner),
         ExecuteMsg::AddVamm { vamm } => add_vamm(deps, info, vamm),
         ExecuteMsg::RemoveVamm { vamm } => remove_vamm(deps, info, vamm),
         ExecuteMsg::Withdraw { token, amount } => withdraw(deps, info, token, amount),

--- a/contracts/margined_insurance_fund/src/contract.rs
+++ b/contracts/margined_insurance_fund/src/contract.rs
@@ -8,7 +8,7 @@ use crate::{
     state::{store_config, Config},
 };
 use cosmwasm_std::{
-    entry_point, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
 };
 use cw2::set_contract_version;
 use margined_perp::margined_insurance_fund::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -23,13 +23,13 @@ pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    _msg: InstantiateMsg,
+    msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let config = Config {
         owner: info.sender,
-        beneficiary: Addr::unchecked(""),
+        beneficiary: deps.api.addr_validate(&msg.beneficiary)?,
     };
 
     store_config(deps.storage, &config)?;

--- a/contracts/margined_insurance_fund/src/handle.rs
+++ b/contracts/margined_insurance_fund/src/handle.rs
@@ -17,7 +17,6 @@ pub fn update_config(
     deps: DepsMut,
     info: MessageInfo,
     owner: Option<String>,
-    beneficiary: Option<String>,
 ) -> StdResult<Response> {
     let mut config: Config = read_config(deps.storage)?;
 
@@ -29,11 +28,6 @@ pub fn update_config(
     // change owner of insurance fund contract
     if let Some(owner) = owner {
         config.owner = deps.api.addr_validate(owner.as_str())?;
-    }
-
-    // change beneficiary of insurance fund contract
-    if let Some(beneficiary) = beneficiary {
-        config.beneficiary = deps.api.addr_validate(beneficiary.as_str())?;
     }
 
     store_config(deps.storage, &config)?;

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -12,7 +12,9 @@ const BENEFICIARY: &str = "beneficiary";
 #[test]
 fn test_instantiation() {
     let mut deps = mock_dependencies();
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -31,14 +33,15 @@ fn test_instantiation() {
 #[test]
 fn test_update_config() {
     let mut deps = mock_dependencies();
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("addr0000", &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // Update the config
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("addr0001".to_string()),
-        beneficiary: Some(BENEFICIARY.to_string()),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -632,7 +635,9 @@ fn test_vamm_capacity() {
 fn test_not_owner() {
     //instantiate contract here
     let mut deps = mock_dependencies();
-    let msg = InstantiateMsg {};
+    let msg = InstantiateMsg {
+        beneficiary: BENEFICIARY.to_string(),
+    };
     let info = mock_info("owner", &[]);
 
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -640,7 +645,6 @@ fn test_not_owner() {
     // try to update the config
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("addr0001".to_string()),
-        beneficiary: None,
     };
 
     let info = mock_info("not_the_owner", &[]);

--- a/contracts/margined_insurance_fund/src/testing/tests.rs
+++ b/contracts/margined_insurance_fund/src/testing/tests.rs
@@ -24,7 +24,7 @@ fn test_instantiation() {
     assert_eq!(
         config,
         ConfigResponse {
-            beneficiary: Addr::unchecked("".to_string()),
+            beneficiary: Addr::unchecked(BENEFICIARY.to_string()),
             owner: info.sender
         }
     );

--- a/packages/margined_perp/src/margined_insurance_fund.rs
+++ b/packages/margined_perp/src/margined_insurance_fund.rs
@@ -4,25 +4,17 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Uint128};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct InstantiateMsg {}
+pub struct InstantiateMsg {
+    pub beneficiary: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    UpdateConfig {
-        owner: Option<String>,
-        beneficiary: Option<String>,
-    },
-    AddVamm {
-        vamm: String,
-    },
-    RemoveVamm {
-        vamm: String,
-    },
-    Withdraw {
-        token: AssetInfo,
-        amount: Uint128,
-    },
+    UpdateConfig { owner: Option<String> },
+    AddVamm { vamm: String },
+    RemoveVamm { vamm: String },
+    Withdraw { token: AssetInfo, amount: Uint128 },
     ShutdownVamms {},
 }
 

--- a/packages/margined_utils/src/contracts/helpers/margined_insurance_fund.rs
+++ b/packages/margined_utils/src/contracts/helpers/margined_insurance_fund.rs
@@ -34,12 +34,8 @@ impl InsuranceFundController {
     /////////////////////////
 
     #[allow(clippy::too_many_arguments)]
-    pub fn update_config(
-        &self,
-        owner: Option<String>,
-        beneficiary: Option<String>,
-    ) -> StdResult<CosmosMsg> {
-        let msg = ExecuteMsg::UpdateConfig { owner, beneficiary };
+    pub fn update_config(&self, owner: Option<String>) -> StdResult<CosmosMsg> {
+        let msg = ExecuteMsg::UpdateConfig { owner };
         self.call(msg, vec![])
     }
 

--- a/packages/margined_utils/src/scenarios/mod.rs
+++ b/packages/margined_utils/src/scenarios/mod.rs
@@ -5,11 +5,9 @@ use crate::contracts::helpers::{
 };
 use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg, Empty, Response, Uint128};
 use cw20::{Cw20Coin, Cw20Contract, Cw20ExecuteMsg, MinterResponse};
-use margined_perp::margined_engine::{InstantiateMsg, Side};
+use margined_perp::margined_engine::{ExecuteMsg, InstantiateMsg, Side};
 use margined_perp::margined_fee_pool::InstantiateMsg as FeePoolInstantiateMsg;
-use margined_perp::margined_insurance_fund::{
-    ExecuteMsg as InsuranceFundExecuteMsg, InstantiateMsg as InsuranceFundInstantiateMsg,
-};
+use margined_perp::margined_insurance_fund::InstantiateMsg as InsuranceFundInstantiateMsg;
 use margined_perp::margined_pricefeed::{
     ExecuteMsg as PricefeedExecuteMsg, InstantiateMsg as PricefeedInstantiateMsg,
 };
@@ -92,11 +90,34 @@ impl NativeTokenScenario {
             .unwrap();
         let fee_pool = FeePoolController(fee_pool_addr);
 
+        // set up margined engine contract
+        let engine_addr = router
+            .instantiate_contract(
+                engine_id,
+                owner.clone(),
+                &InstantiateMsg {
+                    pauser: owner.to_string(),
+                    insurance_fund: "insurance_fund".to_string(),
+                    fee_pool: fee_pool.addr().to_string(),
+                    eligible_collateral: native_denom.to_string(),
+                    initial_margin_ratio: Uint128::from(50_000u128), // 0.05
+                    maintenance_margin_ratio: Uint128::from(50_000u128), // 0.05
+                    liquidation_fee: Uint128::from(50_000u128),      // 0.05
+                },
+                &[],
+                "engine",
+                None,
+            )
+            .unwrap();
+        let engine = EngineController(engine_addr.clone());
+
         let insurance_fund_addr = router
             .instantiate_contract(
                 insurance_fund_id,
                 owner.clone(),
-                &InsuranceFundInstantiateMsg {},
+                &InsuranceFundInstantiateMsg {
+                    beneficiary: engine_addr.to_string(),
+                },
                 &[],
                 "insurance_fund",
                 None,
@@ -110,6 +131,26 @@ impl NativeTokenScenario {
             amount: init_funds,
         });
         router.execute(bank.clone(), msg).unwrap();
+
+        // set insurance fund in margin engine
+        router
+            .execute_contract(
+                owner.clone(),
+                engine_addr.clone(),
+                &ExecuteMsg::UpdateConfig {
+                    owner: None,
+                    pauser: None,
+                    insurance_fund: Some(insurance_fund.addr().to_string()),
+                    fee_pool: None,
+                    eligible_collateral: None,
+                    initial_margin_ratio: None,
+                    maintenance_margin_ratio: None,
+                    partial_liquidation_ratio: None,
+                    liquidation_fee: None,
+                },
+                &[],
+            )
+            .unwrap();
 
         let pricefeed_addr = router
             .instantiate_contract(
@@ -156,27 +197,6 @@ impl NativeTokenScenario {
         let msg = insurance_fund.add_vamm(vamm.addr().to_string()).unwrap();
         router.execute(owner.clone(), msg).unwrap();
 
-        // set up margined engine contract
-        let engine_addr = router
-            .instantiate_contract(
-                engine_id,
-                owner.clone(),
-                &InstantiateMsg {
-                    pauser: owner.to_string(),
-                    insurance_fund: insurance_fund.addr().to_string(),
-                    fee_pool: fee_pool.addr().to_string(),
-                    eligible_collateral: native_denom.to_string(),
-                    initial_margin_ratio: Uint128::from(50_000u128), // 0.05
-                    maintenance_margin_ratio: Uint128::from(50_000u128), // 0.05
-                    liquidation_fee: Uint128::from(50_000u128),      // 0.05
-                },
-                &[],
-                "engine",
-                None,
-            )
-            .unwrap();
-        let engine = EngineController(engine_addr.clone());
-
         // set margin engine in vamm
         router
             .execute_contract(
@@ -192,19 +212,6 @@ impl NativeTokenScenario {
                     margin_engine: Some(engine_addr.to_string()),
                     pricefeed: None,
                     spot_price_twap_interval: None,
-                },
-                &[],
-            )
-            .unwrap();
-
-        // set margin engine as insurance fund beneficiary
-        router
-            .execute_contract(
-                owner.clone(),
-                insurance_fund_addr,
-                &InsuranceFundExecuteMsg::UpdateConfig {
-                    owner: None,
-                    beneficiary: Some(engine_addr.to_string()),
                 },
                 &[],
             )
@@ -309,18 +316,6 @@ impl SimpleScenario {
         let insurance_fund_id = router.store_code(contract_insurance_fund());
         let pricefeed_id = router.store_code(contract_mock_pricefeed());
 
-        let insurance_fund_addr = router
-            .instantiate_contract(
-                insurance_fund_id,
-                owner.clone(),
-                &InsuranceFundInstantiateMsg {},
-                &[],
-                "insurance_fund",
-                None,
-            )
-            .unwrap();
-        let insurance_fund = InsuranceFundController(insurance_fund_addr.clone());
-
         let fee_pool_addr = router
             .instantiate_contract(
                 fee_pool_id,
@@ -354,10 +349,6 @@ impl SimpleScenario {
                             address: david.to_string(),
                             amount: to_decimals(5000),
                         },
-                        Cw20Coin {
-                            address: insurance_fund.addr().to_string(),
-                            amount: to_decimals(5000),
-                        },
                     ],
                     mint: Some(MinterResponse {
                         minter: owner.to_string(),
@@ -372,6 +363,73 @@ impl SimpleScenario {
             .unwrap();
 
         let usdc = Cw20Contract(usdc_addr.clone());
+
+        // set up margined engine contract
+        let engine_addr = router
+            .instantiate_contract(
+                engine_id,
+                owner.clone(),
+                &InstantiateMsg {
+                    pauser: owner.to_string(),
+                    insurance_fund: "insurance_fund".to_string(),
+                    fee_pool: fee_pool.addr().to_string(),
+                    eligible_collateral: usdc.addr().to_string(),
+                    initial_margin_ratio: Uint128::from(50_000_000u128), // 0.05
+                    maintenance_margin_ratio: Uint128::from(50_000_000u128), // 0.05
+                    liquidation_fee: Uint128::from(50_000_000u128),      // 0.05
+                },
+                &[],
+                "engine",
+                None,
+            )
+            .unwrap();
+        let engine = EngineController(engine_addr.clone());
+
+        let insurance_fund_addr = router
+            .instantiate_contract(
+                insurance_fund_id,
+                owner.clone(),
+                &InsuranceFundInstantiateMsg {
+                    beneficiary: engine.addr().to_string(),
+                },
+                &[],
+                "insurance_fund",
+                None,
+            )
+            .unwrap();
+        let insurance_fund = InsuranceFundController(insurance_fund_addr.clone());
+
+        // set insurance fund in margin engine
+        router
+            .execute_contract(
+                owner.clone(),
+                engine.addr().clone(),
+                &ExecuteMsg::UpdateConfig {
+                    owner: None,
+                    pauser: None,
+                    insurance_fund: Some(insurance_fund.addr().to_string()),
+                    fee_pool: None,
+                    eligible_collateral: None,
+                    initial_margin_ratio: None,
+                    maintenance_margin_ratio: None,
+                    partial_liquidation_ratio: None,
+                    liquidation_fee: None,
+                },
+                &[],
+            )
+            .unwrap();
+
+        router
+            .execute_contract(
+                owner.clone(),
+                usdc_addr.clone(),
+                &Cw20ExecuteMsg::Mint {
+                    recipient: insurance_fund_addr.to_string(),
+                    amount: to_decimals(5000),
+                },
+                &[],
+            )
+            .unwrap();
 
         let pricefeed_addr = router
             .instantiate_contract(
@@ -417,40 +475,6 @@ impl SimpleScenario {
 
         let msg = insurance_fund.add_vamm(vamm.addr().to_string()).unwrap();
         router.execute(owner.clone(), msg).unwrap();
-
-        // set up margined engine contract
-        let engine_addr = router
-            .instantiate_contract(
-                engine_id,
-                owner.clone(),
-                &InstantiateMsg {
-                    pauser: owner.to_string(),
-                    insurance_fund: insurance_fund.addr().to_string(),
-                    fee_pool: fee_pool.addr().to_string(),
-                    eligible_collateral: usdc_addr.to_string(),
-                    initial_margin_ratio: Uint128::from(50_000_000u128), // 0.05
-                    maintenance_margin_ratio: Uint128::from(50_000_000u128), // 0.05
-                    liquidation_fee: Uint128::from(50_000_000u128),      // 0.05
-                },
-                &[],
-                "engine",
-                None,
-            )
-            .unwrap();
-        let engine = EngineController(engine_addr.clone());
-
-        // set margin engine as beneficiary in insurance fund
-        router
-            .execute_contract(
-                owner.clone(),
-                insurance_fund_addr,
-                &InsuranceFundExecuteMsg::UpdateConfig {
-                    owner: None,
-                    beneficiary: Some(engine_addr.to_string()),
-                },
-                &[],
-            )
-            .unwrap();
 
         // set margin engine in vamm
         router
@@ -722,7 +746,9 @@ impl ShutdownScenario {
             .instantiate_contract(
                 insurance_fund_id,
                 owner.clone(),
-                &InsuranceFundInstantiateMsg {},
+                &InsuranceFundInstantiateMsg {
+                    beneficiary: "owner".to_string(),
+                },
                 &[],
                 "insurance_fund",
                 None,

--- a/packages/margined_utils/src/scenarios/mod.rs
+++ b/packages/margined_utils/src/scenarios/mod.rs
@@ -123,7 +123,7 @@ impl NativeTokenScenario {
                 None,
             )
             .unwrap();
-        let insurance_fund = InsuranceFundController(insurance_fund_addr.clone());
+        let insurance_fund = InsuranceFundController(insurance_fund_addr);
 
         // send insurance fund funds
         let msg = CosmosMsg::Bank(BankMsg::Send {
@@ -403,7 +403,7 @@ impl SimpleScenario {
         router
             .execute_contract(
                 owner.clone(),
-                engine.addr().clone(),
+                engine.addr(),
                 &ExecuteMsg::UpdateConfig {
                     owner: None,
                     pauser: None,


### PR DESCRIPTION
It is now impossible to update the insurance fund beneficiary via `UpdateConfig`, and as a consequence the insurance fund now needs to be instantiated with a beneficiary 

Due to these changes, the test scenarios needed to be rejigged