### PR TITLE
overlapping names in the events

### DIFF
--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -230,7 +230,7 @@ pub fn open_position(
         ("action", "open_position"),
         ("vamm", vamm.as_ref()),
         ("trader", trader.as_ref()),
-        ("quote_asset_amount", &quote_asset_amount.to_string()),
+        ("open_position_amount", &quote_asset_amount.to_string()),
         ("leverage", &leverage.to_string()),
     ]))
 }


### PR DESCRIPTION
When fixing les bots I noticed that the vamm and margin engine had overlapping names in their events, which whilst not that bad was less than ideal when parsing all the different informations...